### PR TITLE
docs(config): add Japanese translations and trim verbose comments in config.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.x'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.x'
 
@@ -63,7 +63,7 @@ jobs:
           Compress-Archive -Path $filesToZip -DestinationPath ./output/VRCFTPicoModule.zip
 
       - name: Create Release and Upload Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             ./output/VRCFTPicoModule.dll

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Available keys:
 | `eye_gain` | `1.0, 1.0` | Multiplier applied to gaze X, Y after the diff. `1.0` = pass-through. Final gaze values are clamped to `[-1, 1]` |
 | `eye_gain_y_up` | `1.0` | Extra gain applied only when `Gaze.y >= 0` (looking up). PICO Connect under-reports upward gaze; try `2.5`-`3.0`. Final `Gaze.y` is clamped to `[-1, 1]`. |
 | `eye_gain_y_down` | `1.0` | Extra gain applied only when `Gaze.y < 0` (looking down). Usually leave at `1.0` for PICO. |
+| `wink_latch` | `enable` | Hold the last clean wink pair while PICO's per-eye blink estimator falls back to a symmetric half-lidded value (typically triggered by winking + looking to the FOV edge). Disable for raw PICO output. See `config.ini.example` for the tuning knobs. |
 | `log-raw` | `disable` | Enable CSV logging of the raw 52-blendshape packet + computed eye state |
 | `log-file` | `PicoRawLog.csv` | Log file path (relative resolves next to the DLL) |
 | `log-interval-ms` | `50` | Minimum interval between logged rows |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Available keys:
 |---|---|---|
 | `eye-tracking` | `enable` | Turn the eye stream on/off |
 | `expression-tracking` | `enable` | Turn the expression stream on/off |
-| `eye_gain` | `1.0, 1.0` | Multiplier applied to gaze X, Y after the diff. `1.0` = pass-through |
+| `eye_gain` | `1.0, 1.0` | Multiplier applied to gaze X, Y after the diff. `1.0` = pass-through. Final gaze values are clamped to `[-1, 1]` |
+| `eye_gain_y_up` | `1.0` | Extra gain applied only when `Gaze.y >= 0` (looking up). PICO Connect under-reports upward gaze; try `2.5`-`3.0`. Final `Gaze.y` is clamped to `[-1, 1]`. |
+| `eye_gain_y_down` | `1.0` | Extra gain applied only when `Gaze.y < 0` (looking down). Usually leave at `1.0` for PICO. |
 | `log-raw` | `disable` | Enable CSV logging of the raw 52-blendshape packet + computed eye state |
 | `log-file` | `PicoRawLog.csv` | Log file path (relative resolves next to the DLL) |
 | `log-interval-ms` | `50` | Minimum interval between logged rows |

--- a/README.md
+++ b/README.md
@@ -39,12 +39,44 @@ Done! You have successfully installed the module.
 > To manual change protocol version,
 > you will need change the value of `faceTrackingTransferProtocol` in the `settings.json` file located in the `%AppData%/PICO Connect/` directory to `2` or `1`.
 
-## Configuration  
+## Configuration
 
-To selectively disable eye or facial expression tracking, please follow these steps:  
+On first run the module drops a `config.ini` next to the DLL
+(`%APPDATA%\VRCFaceTracking\CustomLibs\config.ini`). Edit it and restart
+VRCFaceTracking to apply. See [`VRCFTPicoModule/config.ini.example`](VRCFTPicoModule/config.ini.example)
+for the full annotated template.
 
-### 1.Navigate to the module's configuration directory (path can be found in module logs)
-### 2.Create corresponding files:
-   - Create `.disable_eye` to disable eye tracking
-   - Create `.disable_expression` to disable facial expression tracking
-### 3.Restart the VRCFaceTracking for changes to take effect
+Available keys:
+
+| Key | Default | Purpose |
+|---|---|---|
+| `eye-tracking` | `enable` | Turn the eye stream on/off |
+| `expression-tracking` | `enable` | Turn the expression stream on/off |
+| `eye_gain` | `1.0, 1.0` | Multiplier applied to gaze X, Y after the diff. `1.0` = pass-through |
+| `log-raw` | `disable` | Enable CSV logging of the raw 52-blendshape packet + computed eye state |
+| `log-file` | `PicoRawLog.csv` | Log file path (relative resolves next to the DLL) |
+| `log-interval-ms` | `50` | Minimum interval between logged rows |
+| `log-include-visemes` | `disable` | Also log the 20 Pico visemes (index 52..71) |
+
+The legacy `.disable_eye` / `.disable_expression` flag files are still honored.
+
+### Debugging what PICO Connect is sending
+
+Set `log-raw: enable` and open the resulting CSV. Each row contains:
+
+- `wallclock_ms` — receive timestamp on the PC
+- The 52 ARKit-style blendshapes (index 0..51) by name, plus optionally the 20 visemes
+- `Openness_L`, `GazeX_L`, `GazeY_L`, `Openness_R`, `GazeX_R`, `GazeY_R` — the values
+  actually written into `UnifiedTracking.Data.Eye` after this module's computation
+
+> [!NOTE]
+> When `eye-tracking: disable` (or a `.disable_eye` flag file is present), this module does
+> not update `UnifiedTracking.Data.Eye`, so the `Openness_*` / `Gaze*` columns reflect
+> whatever another module last wrote (or the default `0`), not this module's input. Only
+> the raw blendshape columns are meaningful in that case.
+>
+> The `log-include-visemes: enable` option is silently ignored on the legacy protocol
+> (port `29763`) because those packets only carry the 52 ARKit shapes.
+
+This lets you observe the raw Pico input and the module's derived eye state side-by-side
+without patching the DLL or running Wireshark.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Available keys:
 | `eye_gain` | `1.0, 1.0` | Multiplier applied to gaze X, Y after the diff. `1.0` = pass-through. Final gaze values are clamped to `[-1, 1]` |
 | `eye_gain_y_up` | `1.0` | Extra gain applied only when `Gaze.y >= 0` (looking up). PICO Connect under-reports upward gaze; try `2.5`-`3.0`. Final `Gaze.y` is clamped to `[-1, 1]`. |
 | `eye_gain_y_down` | `1.0` | Extra gain applied only when `Gaze.y < 0` (looking down). Usually leave at `1.0` for PICO. |
-| `wink_latch` | `enable` | Hold the last clean wink pair while PICO's per-eye blink estimator falls back to a symmetric half-lidded value (typically triggered by winking + looking to the FOV edge). Disable for raw PICO output. See `config.ini.example` for the tuning knobs. |
+| `wink_latch` | `enable` | Hold the last non-collapsed blink pair while PICO's per-eye blink estimator falls back to a symmetric half-lidded value (typically triggered by winking + looking to the FOV edge). Disable for raw PICO output. See `config.ini.example` for the tuning knobs. |
 | `log-raw` | `disable` | Enable CSV logging of the raw 52-blendshape packet + computed eye state |
 | `log-file` | `PicoRawLog.csv` | Log file path (relative resolves next to the DLL) |
 | `log-interval-ms` | `50` | Minimum interval between logged rows |

--- a/VRCFTPicoModule/Utils/Config.cs
+++ b/VRCFTPicoModule/Utils/Config.cs
@@ -11,6 +11,33 @@ public class Config
     public float EyeGainY { get; private set; } = 1.0f;
     public float EyeGainYUp { get; private set; } = 1.0f;
     public float EyeGainYDown { get; private set; } = 1.0f;
+
+    // Mouth calibration defaults derived from PICO 4 Pro raw-log observations at rest.
+    // Each shape uses `output = clamp01((raw - floor) * gain)` before downstream logic.
+    public float JawOpenFloor { get; private set; } = 0.05f;
+    public float JawOpenGain { get; private set; } = 1.0f;
+    public float MouthFrownFloor { get; private set; } = 0.14f;
+    public float MouthFrownGain { get; private set; } = 2.0f;
+    public float MouthSmileGain { get; private set; } = 1.0f;
+    public float MouthPuckerFloor { get; private set; } = 0.10f;
+    public float MouthPuckerGain { get; private set; } = 1.0f;
+    public float MouthFunnelFloor { get; private set; } = 0.05f;
+    public float MouthRollLowerFloor { get; private set; } = 0.16f;
+    public float MouthRollUpperFloor { get; private set; } = 0.05f;
+
+    // PICO Connect keeps CheekPuff pegged near its noise floor even during a real cheek puff,
+    // and CheekSquint is emitted as a constant. Disabled by default; can be re-enabled for
+    // users on hardware/firmware that produces usable signal.
+    public bool CheekPuffEnabled { get; private set; }
+    public float CheekPuffFloor { get; private set; } = 0.14f;
+    public float CheekPuffGain { get; private set; } = 1.0f;
+    public float CheekPuffCrossThreshold { get; private set; } = 0.25f;
+    public bool CheekSquintEnabled { get; private set; }
+
+    // PICO Connect fires MouthLeft and MouthRight together when the mouth shifts to one side.
+    // Differential mode passes only the dominant side, which prevents the opposite-cheek bleed.
+    public bool MouthLeftRightDifferential { get; private set; } = true;
+
     public bool LogRaw { get; private set; }
     public string LogFile { get; private set; } = "PicoRawLog.csv";
     public int LogIntervalMs { get; private set; } = 50;
@@ -70,6 +97,21 @@ public class Config
                 config.EyeGainYDown,
                 config.LogRaw,
                 config.LogIntervalMs);
+            logger.LogInformation(
+                "mouth calibration: jaw=(floor={JawFloor},gain={JawGain}) frown=(floor={FrownFloor},gain={FrownGain}) smile-gain={SmileGain} pucker=(floor={PuckerFloor},gain={PuckerGain}) funnel-floor={FunnelFloor} roll=(lower-floor={RollLowerFloor},upper-floor={RollUpperFloor}) cheek-puff={CheekPuff} cheek-squint={CheekSquint} mouth-lr-differential={LrDiff}",
+                config.JawOpenFloor,
+                config.JawOpenGain,
+                config.MouthFrownFloor,
+                config.MouthFrownGain,
+                config.MouthSmileGain,
+                config.MouthPuckerFloor,
+                config.MouthPuckerGain,
+                config.MouthFunnelFloor,
+                config.MouthRollLowerFloor,
+                config.MouthRollUpperFloor,
+                config.CheekPuffEnabled,
+                config.CheekSquintEnabled,
+                config.MouthLeftRightDifferential);
         }
         catch (Exception ex)
         {
@@ -107,18 +149,61 @@ public class Config
                     EyeGainY = ParseFloat("eye_gain Y component", parts[1].Trim(), EyeGainY, logger);
                 break;
             case "eye_gain_y_up":
-                EyeGainYUp = ParseFloat("eye_gain_y_up", value, EyeGainYUp, logger, min: 0f);
+                EyeGainYUp = ParseFloat(key, value, EyeGainYUp, logger, min: 0f);
                 break;
             case "eye_gain_y_down":
-                EyeGainYDown = ParseFloat("eye_gain_y_down", value, EyeGainYDown, logger, min: 0f);
+                EyeGainYDown = ParseFloat(key, value, EyeGainYDown, logger, min: 0f);
+                break;
+            case "jaw_open_floor":
+                JawOpenFloor = ParseFloat(key, value, JawOpenFloor, logger, min: 0f);
+                break;
+            case "jaw_open_gain":
+                JawOpenGain = ParseFloat(key, value, JawOpenGain, logger, min: 0f);
+                break;
+            case "mouth_frown_floor":
+                MouthFrownFloor = ParseFloat(key, value, MouthFrownFloor, logger, min: 0f);
+                break;
+            case "mouth_frown_gain":
+                MouthFrownGain = ParseFloat(key, value, MouthFrownGain, logger, min: 0f);
+                break;
+            case "mouth_smile_gain":
+                MouthSmileGain = ParseFloat(key, value, MouthSmileGain, logger, min: 0f);
+                break;
+            case "mouth_pucker_floor":
+                MouthPuckerFloor = ParseFloat(key, value, MouthPuckerFloor, logger, min: 0f);
+                break;
+            case "mouth_pucker_gain":
+                MouthPuckerGain = ParseFloat(key, value, MouthPuckerGain, logger, min: 0f);
+                break;
+            case "mouth_funnel_floor":
+                MouthFunnelFloor = ParseFloat(key, value, MouthFunnelFloor, logger, min: 0f);
+                break;
+            case "mouth_roll_lower_floor":
+                MouthRollLowerFloor = ParseFloat(key, value, MouthRollLowerFloor, logger, min: 0f);
+                break;
+            case "mouth_roll_upper_floor":
+                MouthRollUpperFloor = ParseFloat(key, value, MouthRollUpperFloor, logger, min: 0f);
+                break;
+            case "cheek_puff":
+                CheekPuffEnabled = ParseBoolOr(key, value, CheekPuffEnabled, logger);
+                break;
+            case "cheek_puff_floor":
+                CheekPuffFloor = ParseFloat(key, value, CheekPuffFloor, logger, min: 0f);
+                break;
+            case "cheek_puff_gain":
+                CheekPuffGain = ParseFloat(key, value, CheekPuffGain, logger, min: 0f);
+                break;
+            case "cheek_puff_cross_threshold":
+                CheekPuffCrossThreshold = ParseFloat(key, value, CheekPuffCrossThreshold, logger, min: 0f);
+                break;
+            case "cheek_squint":
+                CheekSquintEnabled = ParseBoolOr(key, value, CheekSquintEnabled, logger);
+                break;
+            case "mouth_lr_differential":
+                MouthLeftRightDifferential = ParseBoolOr(key, value, MouthLeftRightDifferential, logger);
                 break;
             case "log-raw":
-                {
-                    var parsed = ParseBoolEnable(value);
-                    if (parsed is null)
-                        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
-                    else LogRaw = parsed.Value;
-                }
+                LogRaw = ParseBoolOr(key, value, LogRaw, logger);
                 break;
             case "log-file":
                 if (value.Length > 0) LogFile = value;
@@ -131,12 +216,7 @@ public class Config
                         value, LogIntervalMs);
                 break;
             case "log-include-visemes":
-                {
-                    var parsed = ParseBoolEnable(value);
-                    if (parsed is null)
-                        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
-                    else LogIncludeVisemes = parsed.Value;
-                }
+                LogIncludeVisemes = ParseBoolOr(key, value, LogIncludeVisemes, logger);
                 break;
             default:
                 logger.LogWarning("config.ini contains unknown key '{Key}'; ignoring", key);
@@ -152,6 +232,14 @@ public class Config
             "disable" or "disabled" or "false" or "0" or "off" or "no" => false,
             _ => null,
         };
+    }
+
+    private static bool ParseBoolOr(string key, string value, bool @default, ILogger logger)
+    {
+        var parsed = ParseBoolEnable(value);
+        if (parsed is not null) return parsed.Value;
+        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
+        return @default;
     }
 
     private static float ParseFloat(string label, string value, float @default, ILogger logger, float min = float.NegativeInfinity)
@@ -203,6 +291,40 @@ public class Config
         # gaze look upward means the gain (or eye_gain Y) is too high.
         eye_gain_y_up: 1.0
         eye_gain_y_down: 1.0
+
+        # ---- Mouth calibration --------------------------------------------------
+        # PICO Connect emits several mouth blendshapes with a persistent non-zero baseline at
+        # rest (e.g. MouthFrown ~ 0.14 in a neutral face on PICO 4 Pro), which shows up on the
+        # avatar as a permanent frown / puff / lip-roll. Each calibrated shape below is
+        # transformed as:
+        #   output = clamp01((raw - floor) * gain)
+        # so the floor cancels the resting bias and the gain restores expressive range.
+        # Defaults are derived from observed PICO 4 Pro logs; adjust per user/hardware by
+        # watching the raw CSV (see log-raw below).
+        jaw_open_floor: 0.05
+        jaw_open_gain: 1.0
+        mouth_frown_floor: 0.14
+        mouth_frown_gain: 2.0
+        mouth_smile_gain: 1.0
+        mouth_pucker_floor: 0.10
+        mouth_pucker_gain: 1.0
+        mouth_funnel_floor: 0.05
+        mouth_roll_lower_floor: 0.16
+        mouth_roll_upper_floor: 0.05
+
+        # ---- Cheek channels ----------------------------------------------------
+        # PICO Connect does not reliably drive CheekPuff or CheekSquint on tested firmware,
+        # so both are disabled by default. Re-enable if your hardware/firmware differs.
+        cheek_puff: disable
+        cheek_puff_floor: 0.14
+        cheek_puff_gain: 1.0
+        cheek_puff_cross_threshold: 0.25
+        cheek_squint: disable
+
+        # Differential mode for MouthLeft/Right: PICO fires both simultaneously when the mouth
+        # shifts to one side, so this passes only the dominant side to prevent opposite-side
+        # bleed. Disable only if your avatar rig expects the raw simultaneous values.
+        mouth_lr_differential: enable
 
         # Raw value CSV logger. When enabled, one row per received packet is written to `log-file`
         # (rate-limited by log-interval-ms). Useful for observing what PICO Connect is actually

--- a/VRCFTPicoModule/Utils/Config.cs
+++ b/VRCFTPicoModule/Utils/Config.cs
@@ -38,6 +38,19 @@ public class Config
     // Differential mode passes only the dominant side, which prevents the opposite-cheek bleed.
     public bool MouthLeftRightDifferential { get; private set; } = true;
 
+    // PICO's eye-tracking estimator collapses to a symmetric fallback when one eye is
+    // winked while the other is at an extreme gaze angle: both EyeBlink channels
+    // converge to the same mid value (~0.4-0.6), so the avatar goes half-lidded on
+    // both sides. The latch arms on a clean wink (one side >= trigger_high, other side
+    // <= trigger_low), then re-emits the last clean pair while the raw values sit in
+    // the symmetric-collapse zone. It releases on either eyes-open or a real double
+    // blink so ordinary blinking is untouched.
+    public bool WinkLatchEnabled { get; private set; } = true;
+    public float WinkLatchTriggerHigh { get; private set; } = 0.65f;
+    public float WinkLatchTriggerLow { get; private set; } = 0.30f;
+    public float WinkLatchCollapseLow { get; private set; } = 0.35f;
+    public float WinkLatchSymmetryBand { get; private set; } = 0.10f;
+
     public bool LogRaw { get; private set; }
     public string LogFile { get; private set; } = "PicoRawLog.csv";
     public int LogIntervalMs { get; private set; } = 50;
@@ -112,6 +125,13 @@ public class Config
                 config.CheekPuffEnabled,
                 config.CheekSquintEnabled,
                 config.MouthLeftRightDifferential);
+            logger.LogInformation(
+                "wink latch: enabled={Enabled} trigger=(high={High},low={Low}) collapse-low={CollapseLow} symmetry-band={SymBand}",
+                config.WinkLatchEnabled,
+                config.WinkLatchTriggerHigh,
+                config.WinkLatchTriggerLow,
+                config.WinkLatchCollapseLow,
+                config.WinkLatchSymmetryBand);
         }
         catch (Exception ex)
         {
@@ -201,6 +221,21 @@ public class Config
                 break;
             case "mouth_lr_differential":
                 MouthLeftRightDifferential = ParseBoolOr(key, value, MouthLeftRightDifferential, logger);
+                break;
+            case "wink_latch":
+                WinkLatchEnabled = ParseBoolOr(key, value, WinkLatchEnabled, logger);
+                break;
+            case "wink_latch_trigger_high":
+                WinkLatchTriggerHigh = ParseFloat(key, value, WinkLatchTriggerHigh, logger, min: 0f);
+                break;
+            case "wink_latch_trigger_low":
+                WinkLatchTriggerLow = ParseFloat(key, value, WinkLatchTriggerLow, logger, min: 0f);
+                break;
+            case "wink_latch_collapse_low":
+                WinkLatchCollapseLow = ParseFloat(key, value, WinkLatchCollapseLow, logger, min: 0f);
+                break;
+            case "wink_latch_symmetry_band":
+                WinkLatchSymmetryBand = ParseFloat(key, value, WinkLatchSymmetryBand, logger, min: 0f);
                 break;
             case "log-raw":
                 LogRaw = ParseBoolOr(key, value, LogRaw, logger);
@@ -325,6 +360,29 @@ public class Config
         # shifts to one side, so this passes only the dominant side to prevent opposite-side
         # bleed. Disable only if your avatar rig expects the raw simultaneous values.
         mouth_lr_differential: enable
+
+        # ---- Wink latch --------------------------------------------------------
+        # PICO's per-eye blink estimator falls back to a symmetric value (both eyes
+        # ~0.4-0.6) when one eye is winked while the other looks toward the FOV edge,
+        # so the avatar half-lids on both sides. The latch arms on a clean wink and
+        # re-emits the last clean EyeBlink_L / EyeBlink_R pair while the raw values
+        # sit in the symmetric-collapse zone; it releases as soon as both eyes clearly
+        # open or a real double blink is detected, so ordinary blinking is untouched.
+        # Disable if your firmware doesn't exhibit the fallback or you prefer raw
+        # PICO output.
+        wink_latch: enable
+        # Blink >= trigger_high means the eye is considered closed enough to arm as
+        # the "winking side"; opposite eye must be <= trigger_low to consider it open.
+        # trigger_high is also the ceiling of the symmetric-collapse override zone.
+        wink_latch_trigger_high: 0.65
+        wink_latch_trigger_low: 0.30
+        # Lower bound of the symmetric-collapse zone: both eyes in
+        # [collapse_low, trigger_high) with |L - R| < symmetry_band means PICO's
+        # fallback fired and the latch will hold the last clean pair. Keep
+        # collapse_low slightly above trigger_low so genuinely opening eyes
+        # pass through immediately instead of being held.
+        wink_latch_collapse_low: 0.35
+        wink_latch_symmetry_band: 0.10
 
         # Raw value CSV logger. When enabled, one row per received packet is written to `log-file`
         # (rate-limited by log-interval-ms). Useful for observing what PICO Connect is actually

--- a/VRCFTPicoModule/Utils/Config.cs
+++ b/VRCFTPicoModule/Utils/Config.cs
@@ -307,107 +307,183 @@ public class Config
         """
         # VRCFTPicoModule config.ini
         # Lines starting with '#' or ';' are comments. Each entry uses `key: value` format.
+        # On first run this file is auto-created next to the module DLL
+        # (%APPDATA%\VRCFaceTracking\CustomLibs\config.ini). Edit and restart VRCFT.
+        #
+        # VRCFTPicoModule config.ini
+        # `#` または `;` で始まる行はコメント。各項目は `key: value` 形式。
+        # 初回起動時にモジュールDLLの隣 (%APPDATA%\VRCFaceTracking\CustomLibs\config.ini)
+        # に自動生成される。編集後は VRCFT を再起動して反映。
 
-        # Enable or disable tracking channels.
-        # If set to `disable`, VRCFT will not receive that stream from this module.
-        # The legacy `.disable_eye` / `.disable_expression` flag files are still honored for
-        # backwards compatibility.
+        # Enable or disable tracking channels. The legacy `.disable_eye` /
+        # `.disable_expression` flag files are still honored for backwards compatibility.
+        #
+        # トラッキングチャネルの有効/無効。旧来の `.disable_eye` / `.disable_expression`
+        # フラグファイルも後方互換のため引き続き有効。
         eye-tracking: enable
         expression-tracking: enable
 
-        # Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown) diff.
-        # 1.0 = pass-through (identical to upstream lonelyicer behavior).
-        # Increase if your gaze feels too weak; decrease if it overshoots.
-        # Final Gaze.x and Gaze.y are clamped to [-1.0, +1.0] regardless of this multiplier,
-        # so values above 1.0 will saturate at the edges rather than extending the range.
-        # Format: X, Y
+        # Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown)
+        # diff. 1.0 = pass-through. Final Gaze.x/y are clamped to [-1.0, +1.0], so values
+        # > 1.0 saturate at the edges rather than extending the range. Format: X, Y
+        #
+        # 視線倍率。(LookIn - LookOut) / (LookUp - LookDown) 差分の後に適用。
+        # 1.0 でそのまま。最終値は [-1.0, +1.0] にクランプされるため、1.0超の値は
+        # 範囲を広げるのではなく端で飽和する。フォーマット: X, Y
         eye_gain: 1.0, 1.0
 
-        # Asymmetric gain applied to the Y (up/down) axis *before* eye_gain's Y component.
-        # Only the sign-matching side is multiplied:
-        #   Gaze.y >= 0  ->  multiplied by eye_gain_y_up
-        #   Gaze.y <  0  ->  multiplied by eye_gain_y_down
-        # The final Gaze.y is clamped to [-1.0, +1.0].
+        # Asymmetric Y-axis gain applied *before* eye_gain's Y component. Only the
+        # sign-matching side is multiplied (Gaze.y >= 0 uses _up, < 0 uses _down); the
+        # final Gaze.y is still clamped to [-1.0, +1.0]. PICO Connect under-reports
+        # upward gaze (raw Up saturates ~0.25 vs Down ~0.65), so recommended for
+        # PICO 4 Pro / Enterprise: eye_gain_y_up = 2.5-3.0, eye_gain_y_down = 1.0.
         #
-        # PICO Connect tends to under-report upward gaze (raw Up channel saturates ~0.25
-        # while Down reaches ~0.65), so the upward eye motion feels weak on the avatar.
-        # Recommended for PICO 4 Pro / Enterprise: eye_gain_y_up around 2.5 - 3.0,
-        # eye_gain_y_down left at 1.0. Increase gradually; a value that makes forward
-        # gaze look upward means the gain (or eye_gain Y) is too high.
+        # Y軸(上下)の非対称ゲイン。eye_gain の Y 成分より *前* に適用され、符号が一致
+        # する側のみ倍される (Gaze.y >= 0 は _up、< 0 は _down)。最終 Gaze.y は
+        # [-1.0, +1.0] にクランプされる。PICO Connect は上方向視線を過小報告する
+        # (raw Up は ~0.25 で飽和、Down は ~0.65)ため、PICO 4 Pro / Enterprise 推奨値:
+        # eye_gain_y_up = 2.5〜3.0、eye_gain_y_down = 1.0。
         eye_gain_y_up: 1.0
         eye_gain_y_down: 1.0
 
-        # ---- Mouth calibration --------------------------------------------------
-        # PICO Connect emits several mouth blendshapes with a persistent non-zero baseline at
-        # rest (e.g. MouthFrown ~ 0.14 in a neutral face on PICO 4 Pro), which shows up on the
-        # avatar as a permanent frown / puff / lip-roll. Each calibrated shape below is
-        # transformed as:
+        # ---- Mouth calibration ----------------------------------------------------
+        # PICO Connect emits several mouth blendshapes with a non-zero baseline at rest
+        # (e.g. MouthFrown ~ 0.14 on PICO 4 Pro), producing a permanent frown/puff on
+        # the avatar. Each calibrated shape is transformed as:
         #   output = clamp01((raw - floor) * gain)
-        # so the floor cancels the resting bias and the gain restores expressive range.
-        # Defaults are derived from observed PICO 4 Pro logs; adjust per user/hardware by
-        # watching the raw CSV (see log-raw below).
+        # Defaults come from PICO 4 Pro logs; tune per user by watching the raw CSV
+        # (see log-raw below).
+        #
+        # ---- 口周りキャリブレーション ---------------------------------------------
+        # PICO Connect の一部の口 blendshape は無表情時にも非ゼロ値を出力し
+        # (例: PICO 4 Pro の MouthFrown ~ 0.14)、アバターが常に不機嫌な顔になる。
+        # 各シェイプは以下の式で補正:
+        #   output = clamp01((raw - floor) * gain)
+        # デフォルトは PICO 4 Pro のログ由来。個別調整は log-raw の生値CSVを参照。
+
+        # JawOpen ticks at ~0.05-0.08 at rest; floor kills idle wobble.
+        # JawOpen は無表情時に ~0.05-0.08 で揺れる。floor でアイドル揺らぎを除去。
         jaw_open_floor: 0.05
         jaw_open_gain: 1.0
+
+        # MouthFrown raw peaks ~0.23 for an intentional frown, so gain 2.0 restores
+        # a visible range after subtracting the ~0.14 rest floor.
+        #
+        # MouthFrown は意図的にしかめても raw のピークが ~0.23 しかないため、
+        # ~0.14 の静止バイアスを引いた上で gain 2.0 により表現範囲を回復する。
         mouth_frown_floor: 0.14
         mouth_frown_gain: 2.0
+
+        # MouthSmile has no meaningful rest floor. Bump the gain if smiles feel weak.
+        # MouthSmile は静止バイアスなし。笑顔が弱いと感じたら gain を上げる。
         mouth_smile_gain: 1.0
+
+        # MouthPucker sits around 0.10-0.12 at rest.
+        # MouthPucker は無表情時 ~0.10-0.12。
         mouth_pucker_floor: 0.10
         mouth_pucker_gain: 1.0
+
+        # MouthFunnel and both MouthRoll channels have small but consistent floors.
+        # MouthFunnel と MouthRoll (上下) は小さいが安定した底値をもつ。
         mouth_funnel_floor: 0.05
         mouth_roll_lower_floor: 0.16
         mouth_roll_upper_floor: 0.05
 
-        # ---- Cheek channels ----------------------------------------------------
-        # PICO Connect does not reliably drive CheekPuff or CheekSquint on tested firmware,
-        # so both are disabled by default. Re-enable if your hardware/firmware differs.
+        # ---- Cheek channels -------------------------------------------------------
+        # PICO Connect doesn't reliably drive CheekPuff (pinned near noise floor even
+        # during a real puff) or CheekSquint (emitted as a constant). Disabled by
+        # default; re-enable if your hardware/firmware differs.
+        #
+        # ---- 頬チャネル -----------------------------------------------------------
+        # PICO Connect は CheekPuff (実際に頬を膨らませてもノイズ底に張り付く) と
+        # CheekSquint (定数出力) を正しく駆動しない。既定で無効。動作するハードや
+        # ファームでは有効化して構わない。
         cheek_puff: disable
         cheek_puff_floor: 0.14
         cheek_puff_gain: 1.0
+
+        # When cheek_puff is enabled and calibrated CheekPuff exceeds this threshold,
+        # a heuristic re-routes the puff to the OPPOSITE cheek from a clearly-shifted
+        # mouth. Raise if a plain mouth-shift accidentally triggers a puff.
+        #
+        # cheek_puff 有効時、補正後の CheekPuff がこの閾値を超えると、口のシフト方向
+        # と逆側の頬に puff を振り替えるヒューリスティックが働く。単なる口のシフトで
+        # puff が誤発火する場合は値を上げる。
         cheek_puff_cross_threshold: 0.25
+
         cheek_squint: disable
 
-        # Differential mode for MouthLeft/Right: PICO fires both simultaneously when the mouth
-        # shifts to one side, so this passes only the dominant side to prevent opposite-side
-        # bleed. Disable only if your avatar rig expects the raw simultaneous values.
+        # PICO Connect fires MouthLeft and MouthRight together when the mouth shifts,
+        # causing bleed onto the opposite side. Differential mode passes only the
+        # dominant side: max(0, MouthLeft - MouthRight). Disable only if your avatar
+        # rig expects the raw simultaneous values.
+        #
+        # PICO Connect は口が片側にシフトすると MouthLeft と MouthRight を同時に
+        # 出力し、反対側にブリードが出る。差分モードは優勢側のみ通す:
+        # max(0, MouthLeft - MouthRight)。アバターリグが raw の同時値を期待する
+        # 場合のみ無効化。
         mouth_lr_differential: enable
 
-        # ---- Wink latch --------------------------------------------------------
-        # PICO's per-eye blink estimator falls back to a symmetric value (both eyes
-        # ~0.4-0.6) when one eye is winked while the other looks toward the FOV edge,
-        # so the avatar half-lids on both sides. The latch arms on a clean wink and
-        # re-emits the last non-collapsed EyeBlink_L / EyeBlink_R pair while the raw values
-        # sit in the symmetric-collapse zone; it releases as soon as both eyes clearly
-        # open or a real double blink is detected, so ordinary blinking is untouched.
-        # Disable if your firmware doesn't exhibit the fallback or you prefer raw
-        # PICO output.
+        # ---- Wink latch -----------------------------------------------------------
+        # When one eye is winked while the other looks toward the FOV edge, PICO's
+        # blink estimator collapses to a symmetric fallback (~0.4-0.6 on both eyes),
+        # half-lidding the avatar. The latch arms on a clean wink and re-emits the
+        # last non-collapsed EyeBlink_L / EyeBlink_R while raw values sit in the
+        # symmetric-collapse zone. It releases on eyes-open or a real double blink,
+        # so ordinary blinking is untouched. Disable if your firmware doesn't exhibit
+        # the fallback or you prefer raw PICO output.
+        #
+        # ---- Wink ラッチ ----------------------------------------------------------
+        # 片眼をウィンクしつつもう片方が FOV 端を見ると、PICO のまばたき推定が対称
+        # フォールバック (両眼 ~0.4-0.6) に落ちてアバターが両目とも半目になる。
+        # ラッチはクリーンなウィンクで動作し、raw が対称崩壊域にある間は直前の
+        # 非崩壊な EyeBlink_L / EyeBlink_R を再送出。両眼開きまたは通常の両眼
+        # まばたきで解除されるため、普段のまばたきは影響を受けない。この症状が
+        # 出ないファーム、または PICO の raw 出力を優先したい場合は無効化。
         wink_latch: enable
-        # Blink >= trigger_high means the eye is considered closed enough to arm as
-        # the "winking side"; opposite eye must be <= trigger_low to consider it open.
-        # trigger_high is also the ceiling of the symmetric-collapse override zone.
+
+        # trigger_high = closed enough to arm as the winking side (also the ceiling
+        #                of the symmetric-collapse override zone).
+        # trigger_low  = opposite eye must be at or below this to count as open.
+        # collapse_low = lower bound of the symmetric-collapse zone; keep it slightly
+        #                above trigger_low so genuinely opening eyes pass through.
+        # symmetry_band = |EyeBlink_L - EyeBlink_R| tolerance inside the collapse zone.
+        #
+        # trigger_high = ウィンク側として認定するための閉眼の下限 (対称崩壊上書き域の
+        #                上限も兼ねる)。
+        # trigger_low  = 反対側の眼が開いていると認定するための上限。
+        # collapse_low = 対称崩壊域の下限。trigger_low よりわずかに上に置いて、
+        #                本当に開こうとしている眼はそのまま通す。
+        # symmetry_band = 崩壊域内で許容する |EyeBlink_L - EyeBlink_R| の幅。
         wink_latch_trigger_high: 0.65
         wink_latch_trigger_low: 0.30
-        # Lower bound of the symmetric-collapse zone: both eyes in
-        # [collapse_low, trigger_high) with |L - R| < symmetry_band means PICO's
-        # fallback fired and the latch will hold the last non-collapsed pair. Keep
-        # collapse_low slightly above trigger_low so genuinely opening eyes
-        # pass through immediately instead of being held.
         wink_latch_collapse_low: 0.35
         wink_latch_symmetry_band: 0.10
 
-        # Raw value CSV logger. When enabled, one row per received packet is written to `log-file`
-        # (rate-limited by log-interval-ms). Useful for observing what PICO Connect is actually
-        # sending, and for deciding what adjustments are needed.
+        # Raw value CSV logger. Writes one row per received packet to `log-file`
+        # (rate-limited by log-interval-ms). Useful for observing what PICO Connect
+        # actually sends and deciding what adjustments are needed.
+        #
+        # 生値CSVロガー。受信パケット1件につき1行を `log-file` に書き込む
+        # (log-interval-ms でレート制限)。PICO Connect が実際に送っている値の確認と
+        # 調整方針の判断に有用。
         log-raw: disable
 
-        # Path to the log CSV. Relative paths resolve next to the module DLL. Absolute paths are
-        # honored as-is.
+        # Path to the log CSV. Relative paths resolve next to the module DLL.
+        # Absolute paths are honored as-is.
+        #
+        # ログCSVのパス。相対パスはモジュールDLL隣で解決。絶対パスはそのまま使用。
         log-file: PicoRawLog.csv
 
         # Minimum interval between logged rows in milliseconds. 0 = log every packet.
+        # ログ行の最小間隔(ミリ秒)。0 で全パケット記録。
         log-interval-ms: 50
 
-        # Include the 20 Pico visemes (index 52..71) in the CSV. These are not consumed by the
+        # Include the 20 Pico visemes (index 52..71) in the CSV. Not consumed by the
         # module today, but the values still arrive from PICO Connect.
+        #
+        # CSV に PICO の20個の viseme (index 52..71) を含める。現状モジュールは未使用
+        # だが、PICO Connect からは値が到達している。
         log-include-visemes: disable
         """;
 }

--- a/VRCFTPicoModule/Utils/Config.cs
+++ b/VRCFTPicoModule/Utils/Config.cs
@@ -1,0 +1,198 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace VRCFTPicoModule.Utils;
+
+public class Config
+{
+    public bool DisableEye { get; private set; }
+    public bool DisableExpression { get; private set; }
+    public float EyeGainX { get; private set; } = 1.0f;
+    public float EyeGainY { get; private set; } = 1.0f;
+    public bool LogRaw { get; private set; }
+    public string LogFile { get; private set; } = "PicoRawLog.csv";
+    public int LogIntervalMs { get; private set; } = 50;
+    public bool LogIncludeVisemes { get; private set; }
+    public string ModuleDirectory { get; private set; } = "";
+
+    public static Config Load(string moduleDirectory, ILogger logger)
+    {
+        var config = new Config { ModuleDirectory = moduleDirectory };
+
+        if (File.Exists(Path.Combine(moduleDirectory, ".disable_eye")))
+        {
+            config.DisableEye = true;
+            logger.LogInformation("Legacy .disable_eye file detected; eye tracking disabled.");
+        }
+        if (File.Exists(Path.Combine(moduleDirectory, ".disable_expression")))
+        {
+            config.DisableExpression = true;
+            logger.LogInformation("Legacy .disable_expression file detected; expression tracking disabled.");
+        }
+
+        var iniPath = Path.Combine(moduleDirectory, "config.ini");
+        if (!File.Exists(iniPath))
+        {
+            logger.LogInformation("config.ini not found; writing default template to {IniPath}", iniPath);
+            try
+            {
+                File.WriteAllText(iniPath, DefaultIniTemplate());
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning("Failed to write default config.ini: {Message}", ex.Message);
+            }
+            return config;
+        }
+
+        try
+        {
+            foreach (var raw in File.ReadAllLines(iniPath))
+            {
+                var line = raw.Trim();
+                if (line.Length == 0 || line.StartsWith('#') || line.StartsWith(';')) continue;
+                var separator = line.IndexOf(':');
+                if (separator < 0) continue;
+                var key = line[..separator].Trim().ToLowerInvariant();
+                var value = line[(separator + 1)..].Trim();
+                config.ApplyKey(key, value, logger);
+            }
+
+            logger.LogInformation(
+                "config.ini loaded: eye={Eye} expression={Expression} eye_gain=({Gx},{Gy}) log-raw={LogRaw} log-interval-ms={IntervalMs}",
+                !config.DisableEye,
+                !config.DisableExpression,
+                config.EyeGainX,
+                config.EyeGainY,
+                config.LogRaw,
+                config.LogIntervalMs);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning("Failed to parse config.ini: {Message}. Falling back to defaults.", ex.Message);
+        }
+
+        return config;
+    }
+
+    private void ApplyKey(string key, string value, ILogger logger)
+    {
+        switch (key)
+        {
+            case "eye-tracking":
+                {
+                    var parsed = ParseBoolEnable(value);
+                    if (parsed is null)
+                        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
+                    else if (parsed == false) DisableEye = true;
+                }
+                break;
+            case "expression-tracking":
+                {
+                    var parsed = ParseBoolEnable(value);
+                    if (parsed is null)
+                        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
+                    else if (parsed == false) DisableExpression = true;
+                }
+                break;
+            case "eye_gain":
+                var parts = value.Split(',');
+                if (parts.Length >= 1)
+                {
+                    if (float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var gx))
+                        EyeGainX = gx;
+                    else
+                        logger.LogWarning("config.ini eye_gain X component '{Value}' is not a number; keeping default {Default}",
+                            parts[0].Trim(), EyeGainX);
+                }
+                if (parts.Length >= 2)
+                {
+                    if (float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var gy))
+                        EyeGainY = gy;
+                    else
+                        logger.LogWarning("config.ini eye_gain Y component '{Value}' is not a number; keeping default {Default}",
+                            parts[1].Trim(), EyeGainY);
+                }
+                break;
+            case "log-raw":
+                {
+                    var parsed = ParseBoolEnable(value);
+                    if (parsed is null)
+                        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
+                    else LogRaw = parsed.Value;
+                }
+                break;
+            case "log-file":
+                if (value.Length > 0) LogFile = value;
+                break;
+            case "log-interval-ms":
+                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iv) && iv >= 0)
+                    LogIntervalMs = iv;
+                else
+                    logger.LogWarning("config.ini log-interval-ms '{Value}' is not a non-negative integer; keeping default {Default}",
+                        value, LogIntervalMs);
+                break;
+            case "log-include-visemes":
+                {
+                    var parsed = ParseBoolEnable(value);
+                    if (parsed is null)
+                        logger.LogWarning("config.ini {Key}='{Value}' is not a recognized enable/disable value; keeping default", key, value);
+                    else LogIncludeVisemes = parsed.Value;
+                }
+                break;
+            default:
+                logger.LogWarning("config.ini contains unknown key '{Key}'; ignoring", key);
+                break;
+        }
+    }
+
+    private static bool? ParseBoolEnable(string value)
+    {
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "enable" or "enabled" or "true" or "1" or "on" or "yes" => true,
+            "disable" or "disabled" or "false" or "0" or "off" or "no" => false,
+            _ => null,
+        };
+    }
+
+    public string ResolveLogPath()
+    {
+        return Path.IsPathRooted(LogFile) ? LogFile : Path.Combine(ModuleDirectory, LogFile);
+    }
+
+    private static string DefaultIniTemplate() =>
+        """
+        # VRCFTPicoModule config.ini
+        # Lines starting with '#' or ';' are comments. Each entry uses `key: value` format.
+
+        # Enable or disable tracking channels.
+        # If set to `disable`, VRCFT will not receive that stream from this module.
+        # The legacy `.disable_eye` / `.disable_expression` flag files are still honored for
+        # backwards compatibility.
+        eye-tracking: enable
+        expression-tracking: enable
+
+        # Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown) diff.
+        # 1.0 = pass-through (identical to upstream lonelyicer behavior).
+        # Increase if your gaze feels too weak; decrease if it overshoots.
+        # Format: X, Y
+        eye_gain: 1.0, 1.0
+
+        # Raw value CSV logger. When enabled, one row per received packet is written to `log-file`
+        # (rate-limited by log-interval-ms). Useful for observing what PICO Connect is actually
+        # sending, and for deciding what adjustments are needed.
+        log-raw: disable
+
+        # Path to the log CSV. Relative paths resolve next to the module DLL. Absolute paths are
+        # honored as-is.
+        log-file: PicoRawLog.csv
+
+        # Minimum interval between logged rows in milliseconds. 0 = log every packet.
+        log-interval-ms: 50
+
+        # Include the 20 Pico visemes (index 52..71) in the CSV. These are not consumed by the
+        # module today, but the values still arrive from PICO Connect.
+        log-include-visemes: disable
+        """;
+}

--- a/VRCFTPicoModule/Utils/Config.cs
+++ b/VRCFTPicoModule/Utils/Config.cs
@@ -9,6 +9,8 @@ public class Config
     public bool DisableExpression { get; private set; }
     public float EyeGainX { get; private set; } = 1.0f;
     public float EyeGainY { get; private set; } = 1.0f;
+    public float EyeGainYUp { get; private set; } = 1.0f;
+    public float EyeGainYDown { get; private set; } = 1.0f;
     public bool LogRaw { get; private set; }
     public string LogFile { get; private set; } = "PicoRawLog.csv";
     public int LogIntervalMs { get; private set; } = 50;
@@ -59,11 +61,13 @@ public class Config
             }
 
             logger.LogInformation(
-                "config.ini loaded: eye={Eye} expression={Expression} eye_gain=({Gx},{Gy}) log-raw={LogRaw} log-interval-ms={IntervalMs}",
+                "config.ini loaded: eye={Eye} expression={Expression} eye_gain=({Gx},{Gy}) eye_gain_y=(up={GyUp},down={GyDown}) log-raw={LogRaw} log-interval-ms={IntervalMs}",
                 !config.DisableEye,
                 !config.DisableExpression,
                 config.EyeGainX,
                 config.EyeGainY,
+                config.EyeGainYUp,
+                config.EyeGainYDown,
                 config.LogRaw,
                 config.LogIntervalMs);
         }
@@ -98,21 +102,15 @@ public class Config
             case "eye_gain":
                 var parts = value.Split(',');
                 if (parts.Length >= 1)
-                {
-                    if (float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var gx))
-                        EyeGainX = gx;
-                    else
-                        logger.LogWarning("config.ini eye_gain X component '{Value}' is not a number; keeping default {Default}",
-                            parts[0].Trim(), EyeGainX);
-                }
+                    EyeGainX = ParseFloat("eye_gain X component", parts[0].Trim(), EyeGainX, logger);
                 if (parts.Length >= 2)
-                {
-                    if (float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var gy))
-                        EyeGainY = gy;
-                    else
-                        logger.LogWarning("config.ini eye_gain Y component '{Value}' is not a number; keeping default {Default}",
-                            parts[1].Trim(), EyeGainY);
-                }
+                    EyeGainY = ParseFloat("eye_gain Y component", parts[1].Trim(), EyeGainY, logger);
+                break;
+            case "eye_gain_y_up":
+                EyeGainYUp = ParseFloat("eye_gain_y_up", value, EyeGainYUp, logger, min: 0f);
+                break;
+            case "eye_gain_y_down":
+                EyeGainYDown = ParseFloat("eye_gain_y_down", value, EyeGainYDown, logger, min: 0f);
                 break;
             case "log-raw":
                 {
@@ -156,6 +154,17 @@ public class Config
         };
     }
 
+    private static float ParseFloat(string label, string value, float @default, ILogger logger, float min = float.NegativeInfinity)
+    {
+        if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            && float.IsFinite(parsed) && parsed >= min)
+            return parsed;
+        var kind = min > float.NegativeInfinity ? $"a finite number >= {min}" : "a finite number";
+        logger.LogWarning("config.ini {Label} '{Value}' is not {Kind}; keeping default {Default}",
+            label, value, kind, @default);
+        return @default;
+    }
+
     public string ResolveLogPath()
     {
         return Path.IsPathRooted(LogFile) ? LogFile : Path.Combine(ModuleDirectory, LogFile);
@@ -176,8 +185,24 @@ public class Config
         # Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown) diff.
         # 1.0 = pass-through (identical to upstream lonelyicer behavior).
         # Increase if your gaze feels too weak; decrease if it overshoots.
+        # Final Gaze.x and Gaze.y are clamped to [-1.0, +1.0] regardless of this multiplier,
+        # so values above 1.0 will saturate at the edges rather than extending the range.
         # Format: X, Y
         eye_gain: 1.0, 1.0
+
+        # Asymmetric gain applied to the Y (up/down) axis *before* eye_gain's Y component.
+        # Only the sign-matching side is multiplied:
+        #   Gaze.y >= 0  ->  multiplied by eye_gain_y_up
+        #   Gaze.y <  0  ->  multiplied by eye_gain_y_down
+        # The final Gaze.y is clamped to [-1.0, +1.0].
+        #
+        # PICO Connect tends to under-report upward gaze (raw Up channel saturates ~0.25
+        # while Down reaches ~0.65), so the upward eye motion feels weak on the avatar.
+        # Recommended for PICO 4 Pro / Enterprise: eye_gain_y_up around 2.5 - 3.0,
+        # eye_gain_y_down left at 1.0. Increase gradually; a value that makes forward
+        # gaze look upward means the gain (or eye_gain Y) is too high.
+        eye_gain_y_up: 1.0
+        eye_gain_y_down: 1.0
 
         # Raw value CSV logger. When enabled, one row per received packet is written to `log-file`
         # (rate-limited by log-interval-ms). Useful for observing what PICO Connect is actually

--- a/VRCFTPicoModule/Utils/Config.cs
+++ b/VRCFTPicoModule/Utils/Config.cs
@@ -42,7 +42,7 @@ public class Config
     // winked while the other is at an extreme gaze angle: both EyeBlink channels
     // converge to the same mid value (~0.4-0.6), so the avatar goes half-lidded on
     // both sides. The latch arms on a clean wink (one side >= trigger_high, other side
-    // <= trigger_low), then re-emits the last clean pair while the raw values sit in
+    // <= trigger_low), then re-emits the last non-collapsed pair while the raw values sit in
     // the symmetric-collapse zone. It releases on either eyes-open or a real double
     // blink so ordinary blinking is untouched.
     public bool WinkLatchEnabled { get; private set; } = true;
@@ -132,6 +132,16 @@ public class Config
                 config.WinkLatchTriggerLow,
                 config.WinkLatchCollapseLow,
                 config.WinkLatchSymmetryBand);
+            // Blink values live in [0, 1]; thresholds outside that range or ordered wrong
+            // never match, silently turning the latch into a no-op.
+            if (config.WinkLatchEnabled
+                && (config.WinkLatchTriggerHigh > 1f
+                    || config.WinkLatchTriggerLow >= config.WinkLatchTriggerHigh
+                    || config.WinkLatchCollapseLow <= config.WinkLatchTriggerLow
+                    || config.WinkLatchCollapseLow >= config.WinkLatchTriggerHigh
+                    || config.WinkLatchSymmetryBand <= 0f))
+                logger.LogWarning(
+                    "config.ini wink latch thresholds are inconsistent (expected 0 <= trigger_low < collapse_low < trigger_high <= 1 and symmetry_band > 0); the latch may never engage");
         }
         catch (Exception ex)
         {
@@ -365,7 +375,7 @@ public class Config
         # PICO's per-eye blink estimator falls back to a symmetric value (both eyes
         # ~0.4-0.6) when one eye is winked while the other looks toward the FOV edge,
         # so the avatar half-lids on both sides. The latch arms on a clean wink and
-        # re-emits the last clean EyeBlink_L / EyeBlink_R pair while the raw values
+        # re-emits the last non-collapsed EyeBlink_L / EyeBlink_R pair while the raw values
         # sit in the symmetric-collapse zone; it releases as soon as both eyes clearly
         # open or a real double blink is detected, so ordinary blinking is untouched.
         # Disable if your firmware doesn't exhibit the fallback or you prefer raw
@@ -378,7 +388,7 @@ public class Config
         wink_latch_trigger_low: 0.30
         # Lower bound of the symmetric-collapse zone: both eyes in
         # [collapse_low, trigger_high) with |L - R| < symmetry_band means PICO's
-        # fallback fired and the latch will hold the last clean pair. Keep
+        # fallback fired and the latch will hold the last non-collapsed pair. Keep
         # collapse_low slightly above trigger_low so genuinely opening eyes
         # pass through immediately instead of being held.
         wink_latch_collapse_low: 0.35

--- a/VRCFTPicoModule/Utils/RawValueLogger.cs
+++ b/VRCFTPicoModule/Utils/RawValueLogger.cs
@@ -1,0 +1,186 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using VRCFTPicoModule.Data;
+
+namespace VRCFTPicoModule.Utils;
+
+public class RawValueLogger : IDisposable
+{
+    private readonly string _filePath;
+    private readonly int _intervalMs;
+    private readonly bool _includeVisemes;
+    private readonly bool _visemesForcedOff;
+    private readonly ILogger _logger;
+    private readonly ConcurrentQueue<Row> _queue = new();
+    private readonly ManualResetEventSlim _wake = new(false);
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Thread _thread;
+    private long _lastEnqueueTick;
+    private bool _started;
+
+    private readonly struct Row
+    {
+        public readonly long WallclockMs;
+        public readonly float[] Shapes;
+        public readonly float LeftOpenness;
+        public readonly float LeftGazeX;
+        public readonly float LeftGazeY;
+        public readonly float RightOpenness;
+        public readonly float RightGazeX;
+        public readonly float RightGazeY;
+
+        public Row(long ms, float[] shapes,
+                   float lo, float lx, float ly,
+                   float ro, float rx, float ry)
+        {
+            WallclockMs = ms; Shapes = shapes;
+            LeftOpenness = lo; LeftGazeX = lx; LeftGazeY = ly;
+            RightOpenness = ro; RightGazeX = rx; RightGazeY = ry;
+        }
+    }
+
+    public RawValueLogger(string filePath, int intervalMs, bool includeVisemes, bool isLegacy, ILogger logger)
+    {
+        _filePath = filePath;
+        _intervalMs = Math.Max(0, intervalMs);
+        // Legacy packets only carry 52 shapes, so requesting visemes would produce rows with
+        // fewer columns than the header. Force visemes off in that case (and warn once in Start()).
+        _includeVisemes = includeVisemes && !isLegacy;
+        _visemesForcedOff = includeVisemes && isLegacy;
+        _logger = logger;
+        _thread = new Thread(WriterLoop) { IsBackground = true, Name = "PicoRawValueLogger" };
+    }
+
+    public void Start()
+    {
+        try
+        {
+            if (_visemesForcedOff)
+                _logger.LogWarning("log-include-visemes was requested but the legacy protocol only carries 52 shapes; visemes column will be omitted from the CSV.");
+
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            WriteHeaderIfMissing();
+            _thread.Start();
+            _started = true;
+            _logger.LogInformation("Raw value logger writing to {FilePath} (interval={IntervalMs} ms, visemes={IncludeVisemes})",
+                _filePath, _intervalMs, _includeVisemes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Failed to start raw value logger: {Message}", ex.Message);
+        }
+    }
+
+    public void Enqueue(float[] shapes,
+                        float leftOpenness, float leftGazeX, float leftGazeY,
+                        float rightOpenness, float rightGazeX, float rightGazeY)
+    {
+        if (!_started || shapes.Length == 0) return;
+
+        var nowMs = Environment.TickCount64;
+        if (nowMs - Volatile.Read(ref _lastEnqueueTick) < _intervalMs) return;
+        Volatile.Write(ref _lastEnqueueTick, nowMs);
+
+        var snap = new float[shapes.Length];
+        Array.Copy(shapes, snap, shapes.Length);
+        _queue.Enqueue(new Row(nowMs, snap,
+            leftOpenness, leftGazeX, leftGazeY,
+            rightOpenness, rightGazeX, rightGazeY));
+        _wake.Set();
+    }
+
+    private void WriteHeaderIfMissing()
+    {
+        if (File.Exists(_filePath) && new FileInfo(_filePath).Length > 0) return;
+
+        var sb = new StringBuilder();
+        sb.Append("wallclock_ms");
+        var upper = _includeVisemes ? 72 : 52;
+        for (var i = 0; i < upper; i++)
+        {
+            sb.Append(',').Append(((BlendShape.Index)i).ToString());
+        }
+        sb.Append(",Openness_L,GazeX_L,GazeY_L,Openness_R,GazeX_R,GazeY_R\n");
+        File.WriteAllText(_filePath, sb.ToString());
+    }
+
+    private void WriterLoop()
+    {
+        try
+        {
+            using var stream = new FileStream(_filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            var flushCounter = 0;
+            var upper = _includeVisemes ? 72 : 52;
+            var ci = CultureInfo.InvariantCulture;
+
+            while (!_cts.IsCancellationRequested)
+            {
+                try { _wake.Wait(1000, _cts.Token); }
+                catch (OperationCanceledException) { break; }
+                _wake.Reset();
+
+                while (_queue.TryDequeue(out var row))
+                {
+                    writer.Write(row.WallclockMs.ToString(ci));
+                    var limit = Math.Min(upper, row.Shapes.Length);
+                    for (var i = 0; i < limit; i++)
+                    {
+                        writer.Write(',');
+                        writer.Write(row.Shapes[i].ToString("F4", ci));
+                    }
+                    writer.Write(',');
+                    writer.Write(row.LeftOpenness.ToString("F4", ci));
+                    writer.Write(',');
+                    writer.Write(row.LeftGazeX.ToString("F4", ci));
+                    writer.Write(',');
+                    writer.Write(row.LeftGazeY.ToString("F4", ci));
+                    writer.Write(',');
+                    writer.Write(row.RightOpenness.ToString("F4", ci));
+                    writer.Write(',');
+                    writer.Write(row.RightGazeX.ToString("F4", ci));
+                    writer.Write(',');
+                    writer.Write(row.RightGazeY.ToString("F4", ci));
+                    writer.Write('\n');
+
+                    if (++flushCounter >= 20)
+                    {
+                        writer.Flush();
+                        flushCounter = 0;
+                    }
+                }
+                writer.Flush();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Raw value logger writer thread stopped: {Message}", ex.Message);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_started)
+        {
+            _cts.Dispose();
+            _wake.Dispose();
+            return;
+        }
+        try
+        {
+            _cts.Cancel();
+            _wake.Set();
+            _thread.Join(500);
+        }
+        catch
+        {
+            // best-effort shutdown
+        }
+        _cts.Dispose();
+        _wake.Dispose();
+    }
+}

--- a/VRCFTPicoModule/Utils/Updater.cs
+++ b/VRCFTPicoModule/Utils/Updater.cs
@@ -140,8 +140,31 @@ namespace VRCFTPicoModule.Utils
 
         private void UpdateExpression(float[] pShape)
         {
+            // Calibrated inputs: (raw - floor) * gain, clamped to [0, 1]. Reused across regions.
+            var jawOpen = Calibrate(pShape[(int)BlendShape.Index.JawOpen], _config.JawOpenFloor, _config.JawOpenGain);
+            var mouthFrownLeft = Calibrate(pShape[(int)BlendShape.Index.MouthFrown_L], _config.MouthFrownFloor, _config.MouthFrownGain);
+            var mouthFrownRight = Calibrate(pShape[(int)BlendShape.Index.MouthFrown_R], _config.MouthFrownFloor, _config.MouthFrownGain);
+            var mouthSmileLeft = Calibrate(pShape[(int)BlendShape.Index.MouthSmile_L], 0f, _config.MouthSmileGain);
+            var mouthSmileRight = Calibrate(pShape[(int)BlendShape.Index.MouthSmile_R], 0f, _config.MouthSmileGain);
+            var mouthPucker = Calibrate(pShape[(int)BlendShape.Index.MouthPucker], _config.MouthPuckerFloor, _config.MouthPuckerGain);
+            var mouthFunnel = Calibrate(pShape[(int)BlendShape.Index.MouthFunnel], _config.MouthFunnelFloor, 1f);
+            var mouthRollLower = Calibrate(pShape[(int)BlendShape.Index.MouthRollLower], _config.MouthRollLowerFloor, 1f);
+            var mouthRollUpper = Calibrate(pShape[(int)BlendShape.Index.MouthRollUpper], _config.MouthRollUpperFloor, 1f);
+            var cheekPuff = _config.CheekPuffEnabled
+                ? Calibrate(pShape[(int)BlendShape.Index.CheekPuff], _config.CheekPuffFloor, _config.CheekPuffGain)
+                : 0f;
+            var mouthPressLeft = pShape[(int)BlendShape.Index.MouthPress_L];
+            var mouthPressRight = pShape[(int)BlendShape.Index.MouthPress_R];
+
+            // PICO fires MouthLeft and MouthRight simultaneously; keep only the dominant side.
+            var mouthLeftRaw = pShape[(int)BlendShape.Index.MouthLeft];
+            var mouthRightRaw = pShape[(int)BlendShape.Index.MouthRight];
+            var (mouthLeft, mouthRight) = _config.MouthLeftRightDifferential
+                ? (Math.Max(0f, mouthLeftRaw - mouthRightRaw), Math.Max(0f, mouthRightRaw - mouthLeftRaw))
+                : (mouthLeftRaw, mouthRightRaw);
+
             #region Jaw
-            SetParam(pShape, BlendShape.Index.JawOpen, UnifiedExpressions.JawOpen);
+            SetParam(jawOpen, UnifiedExpressions.JawOpen);
             SetParam(pShape, BlendShape.Index.JawLeft, UnifiedExpressions.JawLeft);
             SetParam(pShape, BlendShape.Index.JawRight, UnifiedExpressions.JawRight);
             SetParam(pShape, BlendShape.Index.JawForward, UnifiedExpressions.JawForward);
@@ -149,38 +172,25 @@ namespace VRCFTPicoModule.Utils
             #endregion
 
             #region Cheek
-            SetParam(pShape, BlendShape.Index.CheekSquint_L, UnifiedExpressions.CheekSquintLeft);
-            SetParam(pShape, BlendShape.Index.CheekSquint_R, UnifiedExpressions.CheekSquintRight);
+            SetParam(_config.CheekSquintEnabled ? pShape[(int)BlendShape.Index.CheekSquint_L] : 0f, UnifiedExpressions.CheekSquintLeft);
+            SetParam(_config.CheekSquintEnabled ? pShape[(int)BlendShape.Index.CheekSquint_R] : 0f, UnifiedExpressions.CheekSquintRight);
 
-            var mouthLeft = SmoothValue(pShape[(int)BlendShape.Index.MouthLeft], ref _lastMouthLeft);
-            var mouthRight = SmoothValue(pShape[(int)BlendShape.Index.MouthRight], ref _lastMouthRight);
-
-            var cheekPuff = pShape[(int)BlendShape.Index.CheekPuff];
-            const float diffThreshold = 0.1f;
-
-            if (cheekPuff > 0.1f)
+            // Default: balanced puff. When cheek_puff is enabled AND clearly above the cross
+            // threshold, a mouth clearly shifted one way is treated as the OPPOSITE cheek doing
+            // the real puff (differential smoothed mouth L/R feeds the boost).
+            float cheekPuffLeft = cheekPuff, cheekPuffRight = cheekPuff;
+            if (_config.CheekPuffEnabled && cheekPuff > _config.CheekPuffCrossThreshold)
             {
-                if (mouthLeft > mouthRight + diffThreshold)
-                {
-                    SetParam(cheekPuff, UnifiedExpressions.CheekPuffLeft);
-                    SetParam(cheekPuff + mouthLeft, UnifiedExpressions.CheekPuffRight);
-                }
-                else if (mouthRight > mouthLeft + diffThreshold)
-                {
-                    SetParam(cheekPuff + mouthRight, UnifiedExpressions.CheekPuffLeft);
-                    SetParam(cheekPuff, UnifiedExpressions.CheekPuffRight);
-                }
-                else
-                {
-                    SetParam(pShape, BlendShape.Index.CheekPuff, UnifiedExpressions.CheekPuffLeft);
-                    SetParam(pShape, BlendShape.Index.CheekPuff, UnifiedExpressions.CheekPuffRight);
-                }
+                var smoothedLeft = SmoothValue(mouthLeft, ref _lastMouthLeft);
+                var smoothedRight = SmoothValue(mouthRight, ref _lastMouthRight);
+                const float diffThreshold = 0.15f;
+                if (smoothedLeft > smoothedRight + diffThreshold)
+                    cheekPuffRight = Math.Min(1f, cheekPuff + smoothedLeft);
+                else if (smoothedRight > smoothedLeft + diffThreshold)
+                    cheekPuffLeft = Math.Min(1f, cheekPuff + smoothedRight);
             }
-            else
-            {
-                SetParam(pShape, BlendShape.Index.CheekPuff, UnifiedExpressions.CheekPuffLeft);
-                SetParam(pShape, BlendShape.Index.CheekPuff, UnifiedExpressions.CheekPuffRight);
-            }
+            SetParam(cheekPuffLeft, UnifiedExpressions.CheekPuffLeft);
+            SetParam(cheekPuffRight, UnifiedExpressions.CheekPuffRight);
             #endregion
 
             #region Nose
@@ -194,96 +204,67 @@ namespace VRCFTPicoModule.Utils
             SetParam(pShape, BlendShape.Index.MouthLowerDown_L, UnifiedExpressions.MouthLowerDownLeft);
             SetParam(pShape, BlendShape.Index.MouthLowerDown_R, UnifiedExpressions.MouthLowerDownRight);
 
-            var mouthFrownLeft = pShape[(int)BlendShape.Index.MouthFrown_L];
-            SetParam(pShape[(int)BlendShape.Index.JawOpen] > 0.1f
-                    ? mouthFrownLeft / 2f
-                    : pShape[(int)BlendShape.Index.MouthRollLower] > 0.2f 
-                        ? mouthFrownLeft * 2.5f + pShape[(int)BlendShape.Index.MouthRollLower]
-                        : mouthFrownLeft,
-                UnifiedExpressions.MouthFrownLeft);
+            SetParam(mouthFrownLeft, UnifiedExpressions.MouthFrownLeft);
+            SetParam(mouthFrownRight, UnifiedExpressions.MouthFrownRight);
 
-            var mouthFrownRight = pShape[(int)BlendShape.Index.MouthFrown_R];
-            SetParam(pShape[(int)BlendShape.Index.JawOpen] > 0.1f
-                    ? mouthFrownRight / 2f
-                    : pShape[(int)BlendShape.Index.MouthRollLower] > 0.2f
-                        ? mouthFrownRight * 2.5f + pShape[(int)BlendShape.Index.MouthRollLower]
-                        : mouthFrownRight,
-                UnifiedExpressions.MouthFrownRight);
-            
             SetParam(pShape, BlendShape.Index.MouthDimple_L, UnifiedExpressions.MouthDimpleLeft);
             SetParam(pShape, BlendShape.Index.MouthDimple_R, UnifiedExpressions.MouthDimpleRight);
-            SetParam(pShape, BlendShape.Index.MouthLeft, UnifiedExpressions.MouthUpperLeft);
-            SetParam(pShape, BlendShape.Index.MouthLeft, UnifiedExpressions.MouthLowerLeft);
-            SetParam(pShape, BlendShape.Index.MouthRight, UnifiedExpressions.MouthUpperRight);
-            SetParam(pShape, BlendShape.Index.MouthRight, UnifiedExpressions.MouthLowerRight);
-            SetParam(pShape, BlendShape.Index.MouthPress_L, UnifiedExpressions.MouthPressLeft);
-            SetParam(pShape, BlendShape.Index.MouthPress_R, UnifiedExpressions.MouthPressRight);
+            SetParam(mouthLeft, UnifiedExpressions.MouthUpperLeft);
+            SetParam(mouthLeft, UnifiedExpressions.MouthLowerLeft);
+            SetParam(mouthRight, UnifiedExpressions.MouthUpperRight);
+            SetParam(mouthRight, UnifiedExpressions.MouthLowerRight);
+            SetParam(mouthPressLeft, UnifiedExpressions.MouthPressLeft);
+            SetParam(mouthPressRight, UnifiedExpressions.MouthPressRight);
             SetParam(pShape, BlendShape.Index.MouthShrugLower, UnifiedExpressions.MouthRaiserLower);
             SetParam(pShape, BlendShape.Index.MouthShrugUpper, UnifiedExpressions.MouthRaiserUpper);
 
-            var mouthSmileLeft = pShape[(int)BlendShape.Index.MouthSmile_L] -
-                                 pShape[(int)BlendShape.Index.MouthRollLower];
-            SetParam(pShape[(int)BlendShape.Index.MouthRollLower] < 0.2f
-                    ? mouthSmileLeft
-                    : 0f,
-                UnifiedExpressions.MouthCornerPullLeft);
-            SetParam(pShape[(int)BlendShape.Index.MouthRollLower] < 0.2f
-                    ? mouthSmileLeft - pShape[(int)BlendShape.Index.MouthRollLower]
-                    : 0f,
-                UnifiedExpressions.MouthCornerSlantLeft);
+            // Both sides use calibrated Smile minus calibrated RollLower. At rest both are 0,
+            // so the previous "negative clamp erases the smile" bug is gone; during a real
+            // lip-roll (pucker) the smile still gets suppressed. Slant intentionally mirrors
+            // Pull now that the rest-baseline is subtracted at the source — the upstream code
+            // used a second `- RollLower` on Slant Left only, which looked like a copy-paste
+            // typo (Slant Right did not do the same).
+            var cornerPullLeft = Math.Max(0f, mouthSmileLeft - mouthRollLower);
+            var cornerPullRight = Math.Max(0f, mouthSmileRight - mouthRollLower);
+            SetParam(cornerPullLeft, UnifiedExpressions.MouthCornerPullLeft);
+            SetParam(cornerPullLeft, UnifiedExpressions.MouthCornerSlantLeft);
+            SetParam(cornerPullRight, UnifiedExpressions.MouthCornerPullRight);
+            SetParam(cornerPullRight, UnifiedExpressions.MouthCornerSlantRight);
 
-            var mouthSmileRight = pShape[(int)BlendShape.Index.MouthSmile_R] -
-                                  pShape[(int)BlendShape.Index.MouthRollLower];
-            SetParam(pShape[(int)BlendShape.Index.MouthRollLower] < 0.2f
-                    ? mouthSmileRight
-                    : 0f,
-                UnifiedExpressions.MouthCornerPullRight);
-            SetParam(pShape[(int)BlendShape.Index.MouthRollLower] < 0.2f
-                    ? mouthSmileRight
-                    : 0f,
-                UnifiedExpressions.MouthCornerSlantRight);
-            
             SetParam(pShape, BlendShape.Index.MouthStretch_L, UnifiedExpressions.MouthStretchLeft);
             SetParam(pShape, BlendShape.Index.MouthStretch_R, UnifiedExpressions.MouthStretchRight);
             #endregion
 
             #region Lip
-            var isFunnelLeft = pShape[(int)BlendShape.Index.MouthPucker] > 0.3f &&
-                               pShape[(int)BlendShape.Index.MouthPress_L] < 0.2f;
-            var isFunnelRight = pShape[(int)BlendShape.Index.MouthPucker] > 0.3f &&
-                               pShape[(int)BlendShape.Index.MouthPress_R] < 0.2f;
-            var mouthFunnelFixed = pShape[(int)BlendShape.Index.MouthPucker];
-            SetParam(isFunnelLeft
-                    ? mouthFunnelFixed
-                    : pShape[(int)BlendShape.Index.MouthFunnel],
-                UnifiedExpressions.LipFunnelUpperLeft);
-            SetParam(isFunnelRight
-                    ? mouthFunnelFixed
-                    : pShape[(int)BlendShape.Index.MouthFunnel],
-                UnifiedExpressions.LipFunnelUpperRight);
-            SetParam(isFunnelLeft
-                    ? mouthFunnelFixed
-                    : pShape[(int)BlendShape.Index.MouthFunnel],
-                UnifiedExpressions.LipFunnelLowerLeft);
-            SetParam(isFunnelRight
-                    ? mouthFunnelFixed
-                    : pShape[(int)BlendShape.Index.MouthFunnel],
-                UnifiedExpressions.LipFunnelLowerRight);
-            
-            SetParam(pShape, BlendShape.Index.MouthPucker, UnifiedExpressions.LipPuckerUpperLeft);
-            SetParam(pShape, BlendShape.Index.MouthPucker, UnifiedExpressions.LipPuckerUpperRight);
-            SetParam(pShape, BlendShape.Index.MouthPucker, UnifiedExpressions.LipPuckerLowerLeft);
-            SetParam(pShape, BlendShape.Index.MouthPucker, UnifiedExpressions.LipPuckerLowerRight);
-            SetParam(pShape, BlendShape.Index.MouthRollUpper, UnifiedExpressions.LipSuckUpperLeft);
-            SetParam(pShape, BlendShape.Index.MouthRollUpper, UnifiedExpressions.LipSuckUpperRight);
-            SetParam(pShape, BlendShape.Index.MouthRollLower, UnifiedExpressions.LipSuckLowerLeft);
-            SetParam(pShape, BlendShape.Index.MouthRollLower, UnifiedExpressions.LipSuckLowerRight);
+            // Prefer calibrated pucker over funnel for LipFunnel unless the same side is
+            // pressed shut (raw MouthPress kept — press has no observed baseline). Note that
+            // the 0.3f threshold is applied to the *calibrated* pucker, so raising
+            // mouth_pucker_floor also effectively raises this activation point.
+            var funnelActive = mouthPucker > 0.3f;
+            var funnelLeft = funnelActive && mouthPressLeft < 0.2f ? mouthPucker : mouthFunnel;
+            var funnelRight = funnelActive && mouthPressRight < 0.2f ? mouthPucker : mouthFunnel;
+            SetParam(funnelLeft, UnifiedExpressions.LipFunnelUpperLeft);
+            SetParam(funnelRight, UnifiedExpressions.LipFunnelUpperRight);
+            SetParam(funnelLeft, UnifiedExpressions.LipFunnelLowerLeft);
+            SetParam(funnelRight, UnifiedExpressions.LipFunnelLowerRight);
+
+            SetParam(mouthPucker, UnifiedExpressions.LipPuckerUpperLeft);
+            SetParam(mouthPucker, UnifiedExpressions.LipPuckerUpperRight);
+            SetParam(mouthPucker, UnifiedExpressions.LipPuckerLowerLeft);
+            SetParam(mouthPucker, UnifiedExpressions.LipPuckerLowerRight);
+            SetParam(mouthRollUpper, UnifiedExpressions.LipSuckUpperLeft);
+            SetParam(mouthRollUpper, UnifiedExpressions.LipSuckUpperRight);
+            SetParam(mouthRollLower, UnifiedExpressions.LipSuckLowerLeft);
+            SetParam(mouthRollLower, UnifiedExpressions.LipSuckLowerRight);
             #endregion
 
             #region Tongue
             SetParam(pShape, BlendShape.Index.TongueOut, UnifiedExpressions.TongueOut);
             #endregion
         }
+
+        private static float Calibrate(float raw, float floor, float gain)
+            => Math.Clamp((raw - floor) * gain, 0f, 1f);
 
         private static float SmoothValue(float newValue, ref float lastValue)
         {

--- a/VRCFTPicoModule/Utils/Updater.cs
+++ b/VRCFTPicoModule/Utils/Updater.cs
@@ -35,6 +35,10 @@ namespace VRCFTPicoModule.Utils
         private const float SmoothingFactor = 0.5f;
         private ModuleState _moduleState;
 
+        private bool _winkLatchArmed;
+        private float _latchedBlinkL;
+        private float _latchedBlinkR;
+
         public void Update(ModuleState state)
         {
             if (_udpClient == null)
@@ -55,7 +59,7 @@ namespace VRCFTPicoModule.Utils
                 var pShape = ParseData(data, _isLegacy);
 
                 if (_trackingAvailable.Item1)
-                    UpdateEye(pShape, _config);
+                    UpdateEye(pShape);
 
                 if (_trackingAvailable.Item2)
                     UpdateExpression(pShape);
@@ -93,30 +97,34 @@ namespace VRCFTPicoModule.Utils
             return header.trackingType == 2 ? DataPacketHelpers.ByteArrayToStructure<DataPacket.DataPackBody>(data, Marshal.SizeOf<DataPacket.DataPackHeader>()).blendShapeWeight : [];
         }
 
-        private static void UpdateEye(float[] pShape, Config config)
+        private void UpdateEye(float[] pShape)
         {
             var eye = UnifiedTracking.Data.Eye;
 
+            var (blinkL, blinkR) = ApplyWinkLatch(
+                pShape[(int)BlendShape.Index.EyeBlink_L],
+                pShape[(int)BlendShape.Index.EyeBlink_R]);
+
             #region LeftEye
-            eye.Left.Openness = 1f - pShape[(int)BlendShape.Index.EyeBlink_L];
+            eye.Left.Openness = 1f - blinkL;
             eye.Left.Gaze.x = Math.Clamp(
-                (pShape[(int)BlendShape.Index.EyeLookIn_L] - pShape[(int)BlendShape.Index.EyeLookOut_L]) * config.EyeGainX,
+                (pShape[(int)BlendShape.Index.EyeLookIn_L] - pShape[(int)BlendShape.Index.EyeLookOut_L]) * _config.EyeGainX,
                 -1f, 1f);
             eye.Left.Gaze.y = ComputeGazeY(
                 pShape[(int)BlendShape.Index.EyeLookUp_L],
                 pShape[(int)BlendShape.Index.EyeLookDown_L],
-                config);
+                _config);
             #endregion
 
             #region RightEye
-            eye.Right.Openness = 1f - pShape[(int)BlendShape.Index.EyeBlink_R];
+            eye.Right.Openness = 1f - blinkR;
             eye.Right.Gaze.x = Math.Clamp(
-                (pShape[(int)BlendShape.Index.EyeLookOut_R] - pShape[(int)BlendShape.Index.EyeLookIn_R]) * config.EyeGainX,
+                (pShape[(int)BlendShape.Index.EyeLookOut_R] - pShape[(int)BlendShape.Index.EyeLookIn_R]) * _config.EyeGainX,
                 -1f, 1f);
             eye.Right.Gaze.y = ComputeGazeY(
                 pShape[(int)BlendShape.Index.EyeLookUp_R],
                 pShape[(int)BlendShape.Index.EyeLookDown_R],
-                config);
+                _config);
             #endregion
             
             #region Brow
@@ -270,6 +278,32 @@ namespace VRCFTPicoModule.Utils
         {
             lastValue += (newValue - lastValue) * SmoothingFactor;
             return lastValue;
+        }
+
+        private (float blinkL, float blinkR) ApplyWinkLatch(float bl, float br)
+        {
+            if (!_config.WinkLatchEnabled)
+                return (bl, br);
+
+            var high = _config.WinkLatchTriggerHigh;
+            var low = _config.WinkLatchTriggerLow;
+
+            if ((bl >= high && br <= low) || (br >= high && bl <= low))
+                _winkLatchArmed = true;
+            else if ((bl <= low && br <= low) || (bl >= high && br >= high))
+                _winkLatchArmed = false;
+
+            var inCollapse = _winkLatchArmed
+                          && bl >= _config.WinkLatchCollapseLow && bl < high
+                          && br >= _config.WinkLatchCollapseLow && br < high
+                          && MathF.Abs(bl - br) < _config.WinkLatchSymmetryBand;
+
+            if (inCollapse)
+                return (_latchedBlinkL, _latchedBlinkR);
+
+            _latchedBlinkL = bl;
+            _latchedBlinkR = br;
+            return (bl, br);
         }
 
         private static float ComputeGazeY(float lookUp, float lookDown, Config config)

--- a/VRCFTPicoModule/Utils/Updater.cs
+++ b/VRCFTPicoModule/Utils/Updater.cs
@@ -16,13 +16,17 @@ namespace VRCFTPicoModule.Utils
         private readonly ILogger? _logger;
         private readonly bool _isLegacy;
         private readonly (bool, bool) _trackingAvailable;
+        private readonly Config _config = new();
+        private readonly RawValueLogger? _rawLogger;
 
-        public Updater(UdpClient udpClient, ILogger logger, bool isLegacy, (bool, bool) trackingAvailable) : this()
+        public Updater(UdpClient udpClient, ILogger logger, bool isLegacy, (bool, bool) trackingAvailable, Config config, RawValueLogger? rawLogger) : this()
         {
             _udpClient = udpClient;
             _logger = logger;
             _isLegacy = isLegacy;
             _trackingAvailable = trackingAvailable;
+            _config = config;
+            _rawLogger = rawLogger;
         }
         
         private int _timeOut;
@@ -49,12 +53,20 @@ namespace VRCFTPicoModule.Utils
                 var endPoint = new IPEndPoint(IPAddress.Any, 0);
                 var data = _udpClient.Receive(ref endPoint);
                 var pShape = ParseData(data, _isLegacy);
-                
+
                 if (_trackingAvailable.Item1)
-                    UpdateEye(pShape);
-                
+                    UpdateEye(pShape, _config);
+
                 if (_trackingAvailable.Item2)
                     UpdateExpression(pShape);
+
+                if (_rawLogger != null && pShape.Length > 0)
+                {
+                    var eye = UnifiedTracking.Data.Eye;
+                    _rawLogger.Enqueue(pShape,
+                        eye.Left.Openness, eye.Left.Gaze.x, eye.Left.Gaze.y,
+                        eye.Right.Openness, eye.Right.Gaze.x, eye.Right.Gaze.y);
+                }
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.TimedOut)
             {
@@ -81,20 +93,20 @@ namespace VRCFTPicoModule.Utils
             return header.trackingType == 2 ? DataPacketHelpers.ByteArrayToStructure<DataPacket.DataPackBody>(data, Marshal.SizeOf<DataPacket.DataPackHeader>()).blendShapeWeight : [];
         }
 
-        private static void UpdateEye(float[] pShape)
+        private static void UpdateEye(float[] pShape, Config config)
         {
             var eye = UnifiedTracking.Data.Eye;
 
             #region LeftEye
             eye.Left.Openness = 1f - pShape[(int)BlendShape.Index.EyeBlink_L];
-            eye.Left.Gaze.x = pShape[(int)BlendShape.Index.EyeLookIn_L] - pShape[(int)BlendShape.Index.EyeLookOut_L];
-            eye.Left.Gaze.y = pShape[(int)BlendShape.Index.EyeLookUp_L] - pShape[(int)BlendShape.Index.EyeLookDown_L];
+            eye.Left.Gaze.x = (pShape[(int)BlendShape.Index.EyeLookIn_L] - pShape[(int)BlendShape.Index.EyeLookOut_L]) * config.EyeGainX;
+            eye.Left.Gaze.y = (pShape[(int)BlendShape.Index.EyeLookUp_L] - pShape[(int)BlendShape.Index.EyeLookDown_L]) * config.EyeGainY;
             #endregion
 
             #region RightEye
             eye.Right.Openness = 1f - pShape[(int)BlendShape.Index.EyeBlink_R];
-            eye.Right.Gaze.x = pShape[(int)BlendShape.Index.EyeLookOut_R] - pShape[(int)BlendShape.Index.EyeLookIn_R];
-            eye.Right.Gaze.y = pShape[(int)BlendShape.Index.EyeLookUp_R] - pShape[(int)BlendShape.Index.EyeLookDown_R];
+            eye.Right.Gaze.x = (pShape[(int)BlendShape.Index.EyeLookOut_R] - pShape[(int)BlendShape.Index.EyeLookIn_R]) * config.EyeGainX;
+            eye.Right.Gaze.y = (pShape[(int)BlendShape.Index.EyeLookUp_R] - pShape[(int)BlendShape.Index.EyeLookDown_R]) * config.EyeGainY;
             #endregion
             
             #region Brow

--- a/VRCFTPicoModule/Utils/Updater.cs
+++ b/VRCFTPicoModule/Utils/Updater.cs
@@ -50,7 +50,11 @@ namespace VRCFTPicoModule.Utils
             _udpClient.Client.ReceiveTimeout = 100;
             _moduleState = state;
             
-            if (_moduleState != ModuleState.Active) return;
+            if (_moduleState != ModuleState.Active)
+            {
+                ResetWinkLatch();
+                return;
+            }
 
             try
             {
@@ -78,6 +82,7 @@ namespace VRCFTPicoModule.Utils
                 {
                     _logger.LogWarning(T("update-timeout"));
                     _timeOut = 0;
+                    ResetWinkLatch();
                 }
             }
             catch (Exception ex)
@@ -304,6 +309,15 @@ namespace VRCFTPicoModule.Utils
             _latchedBlinkL = bl;
             _latchedBlinkR = br;
             return (bl, br);
+        }
+
+        // A latched pair is only meaningful while the blink stream is continuous; after a
+        // tracking gap it would re-emit a stale wink, so drop the latch on interruption.
+        private void ResetWinkLatch()
+        {
+            _winkLatchArmed = false;
+            _latchedBlinkL = 0f;
+            _latchedBlinkR = 0f;
         }
 
         private static float ComputeGazeY(float lookUp, float lookDown, Config config)

--- a/VRCFTPicoModule/Utils/Updater.cs
+++ b/VRCFTPicoModule/Utils/Updater.cs
@@ -99,14 +99,24 @@ namespace VRCFTPicoModule.Utils
 
             #region LeftEye
             eye.Left.Openness = 1f - pShape[(int)BlendShape.Index.EyeBlink_L];
-            eye.Left.Gaze.x = (pShape[(int)BlendShape.Index.EyeLookIn_L] - pShape[(int)BlendShape.Index.EyeLookOut_L]) * config.EyeGainX;
-            eye.Left.Gaze.y = (pShape[(int)BlendShape.Index.EyeLookUp_L] - pShape[(int)BlendShape.Index.EyeLookDown_L]) * config.EyeGainY;
+            eye.Left.Gaze.x = Math.Clamp(
+                (pShape[(int)BlendShape.Index.EyeLookIn_L] - pShape[(int)BlendShape.Index.EyeLookOut_L]) * config.EyeGainX,
+                -1f, 1f);
+            eye.Left.Gaze.y = ComputeGazeY(
+                pShape[(int)BlendShape.Index.EyeLookUp_L],
+                pShape[(int)BlendShape.Index.EyeLookDown_L],
+                config);
             #endregion
 
             #region RightEye
             eye.Right.Openness = 1f - pShape[(int)BlendShape.Index.EyeBlink_R];
-            eye.Right.Gaze.x = (pShape[(int)BlendShape.Index.EyeLookOut_R] - pShape[(int)BlendShape.Index.EyeLookIn_R]) * config.EyeGainX;
-            eye.Right.Gaze.y = (pShape[(int)BlendShape.Index.EyeLookUp_R] - pShape[(int)BlendShape.Index.EyeLookDown_R]) * config.EyeGainY;
+            eye.Right.Gaze.x = Math.Clamp(
+                (pShape[(int)BlendShape.Index.EyeLookOut_R] - pShape[(int)BlendShape.Index.EyeLookIn_R]) * config.EyeGainX,
+                -1f, 1f);
+            eye.Right.Gaze.y = ComputeGazeY(
+                pShape[(int)BlendShape.Index.EyeLookUp_R],
+                pShape[(int)BlendShape.Index.EyeLookDown_R],
+                config);
             #endregion
             
             #region Brow
@@ -279,6 +289,13 @@ namespace VRCFTPicoModule.Utils
         {
             lastValue += (newValue - lastValue) * SmoothingFactor;
             return lastValue;
+        }
+
+        private static float ComputeGazeY(float lookUp, float lookDown, Config config)
+        {
+            var raw = lookUp - lookDown;
+            var y = raw * (raw >= 0f ? config.EyeGainYUp : config.EyeGainYDown) * config.EyeGainY;
+            return Math.Clamp(y, -1f, 1f);
         }
 
         private static void SetParam(float[] pShape, BlendShape.Index index, UnifiedExpressions outputType)

--- a/VRCFTPicoModule/VRCFTPicoModule.cs
+++ b/VRCFTPicoModule/VRCFTPicoModule.cs
@@ -15,6 +15,8 @@ public class VRCFTPicoModule : ExtTrackingModule
     private static UdpClient _udpClient = new();
     private static int _port;
     private Updater? _updater;
+    private Config? _config;
+    private RawValueLogger? _rawLogger;
     private (bool, bool) _trackingAvailable;
 
     public override (bool SupportsEye, bool SupportsExpression) Supported => (true, true);
@@ -23,16 +25,16 @@ public class VRCFTPicoModule : ExtTrackingModule
     {
         Localization.Initialize(CultureInfo.CurrentUICulture.Name);
         Logger.LogInformation(T("start-init"));
-        
-        var config = ReadConfiguration();
+
+        _config = LoadConfig();
         _trackingAvailable = (
-            !config.Item1 && eyeAvailable,
-            !config.Item2 && expressionAvailable
+            !_config.DisableEye && eyeAvailable,
+            !_config.DisableExpression && expressionAvailable
         );
-        
+
         var initializationResult = InitializeAsync().GetAwaiter().GetResult();
         UpdateModuleInfo(initializationResult);
-        
+
         return initializationResult;
     }
 
@@ -46,44 +48,44 @@ public class VRCFTPicoModule : ExtTrackingModule
         _port = Ports[portIndex];
         _udpClient = new UdpClient(_port);
         Logger.LogInformation(T("using-port"), _port);
-        
+
         if (!_trackingAvailable.Item1)
             Logger.LogInformation(T("eye-tracking-disabled"));
         if (!_trackingAvailable.Item2)
             Logger.LogInformation(T("expression-tracking-disabled"));
 
-        _updater = new Updater(_udpClient, Logger, _port == Ports[1], _trackingAvailable);
+        if (_config!.LogRaw)
+        {
+            _rawLogger = new RawValueLogger(
+                _config.ResolveLogPath(),
+                _config.LogIntervalMs,
+                _config.LogIncludeVisemes,
+                _port == Ports[1],
+                Logger);
+            _rawLogger.Start();
+        }
+
+        _updater = new Updater(_udpClient, Logger, _port == Ports[1], _trackingAvailable, _config, _rawLogger);
 
         return _trackingAvailable;
     }
 
-    private (bool, bool) ReadConfiguration()
+    private Config LoadConfig()
     {
         var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         Logger.LogInformation(T("config-path"), currentDirectory);
-        
-        if (!Directory.Exists(currentDirectory))
-            return (false, false);
-        
-        var disableEye = false;
-        var disableExpression = false;
-        
-        var eyeFilePath = Path.Combine(currentDirectory, ".disable_eye");
-        if (File.Exists(eyeFilePath))
-        {
-            disableEye = true;
-            Logger.LogInformation(T("force-disable-eye"));
-        }
 
-        var expressionFilePath = Path.Combine(currentDirectory, ".disable_expression");
-        // ReSharper disable once InvertIf
-        if (File.Exists(expressionFilePath))
-        {
-            disableExpression = true;
+        if (string.IsNullOrEmpty(currentDirectory) || !Directory.Exists(currentDirectory))
+            return new Config();
+
+        var config = Config.Load(currentDirectory, Logger);
+
+        if (config.DisableEye)
+            Logger.LogInformation(T("force-disable-eye"));
+        if (config.DisableExpression)
             Logger.LogInformation(T("force-disable-expression"));
-        }
-        
-        return (disableEye, disableExpression);
+
+        return config;
     }
 
     private void UpdateModuleInfo((bool, bool) initializationResult)
@@ -139,5 +141,7 @@ public class VRCFTPicoModule : ExtTrackingModule
         }
         _udpClient.Dispose();
         _updater = null;
+        _rawLogger?.Dispose();
+        _rawLogger = null;
     }
 }

--- a/VRCFTPicoModule/config.ini.example
+++ b/VRCFTPicoModule/config.ini.example
@@ -88,6 +88,33 @@ cheek_squint: disable
 # Disable only if your avatar rig expects raw simultaneous values.
 mouth_lr_differential: enable
 
+# ---- Wink latch -----------------------------------------------------------
+# When one eye is winked while the other looks toward the FOV edge, PICO's
+# blink estimator falls back to a symmetric value (both eyes ~0.4-0.6), so
+# the avatar half-lids on both sides. The latch arms on a clean wink and
+# re-emits the last clean EyeBlink_L / EyeBlink_R pair while the raw values
+# sit in the symmetric-collapse zone. It releases as soon as both eyes clearly
+# open or a real double blink is detected, so ordinary blinking is untouched.
+# Disable if your firmware doesn't exhibit the fallback or you prefer the
+# raw PICO output.
+wink_latch: enable
+
+# Blink >= trigger_high means the eye is considered closed enough to arm as
+# the "winking side"; the opposite eye must be <= trigger_low to count as
+# open. trigger_high is also the ceiling of the symmetric-collapse override
+# zone (see collapse_low below).
+wink_latch_trigger_high: 0.65
+wink_latch_trigger_low: 0.30
+
+# Symmetric-collapse detection: while latched, if both eyes sit in
+# [collapse_low, trigger_high) with |EyeBlink_L - EyeBlink_R| < symmetry_band,
+# the last clean pair is re-emitted instead of the collapsed values.
+# Keep collapse_low slightly above trigger_low: values falling through the
+# (trigger_low, collapse_low) gap are treated as genuinely opening eyes and
+# pass through immediately instead of being held.
+wink_latch_collapse_low: 0.35
+wink_latch_symmetry_band: 0.10
+
 # Raw value CSV logger. When enabled, one row per received packet is written to
 # `log-file` (rate-limited by log-interval-ms). Useful for observing what PICO
 # Connect is actually sending, and for deciding what adjustments are needed.

--- a/VRCFTPicoModule/config.ini.example
+++ b/VRCFTPicoModule/config.ini.example
@@ -14,8 +14,24 @@ expression-tracking: enable
 # Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown) diff.
 # 1.0 = pass-through (identical to upstream lonelyicer behavior).
 # Increase if your gaze feels too weak; decrease if it overshoots.
+# Final Gaze.x and Gaze.y are clamped to [-1.0, +1.0] regardless of this multiplier,
+# so values above 1.0 will saturate at the edges rather than extending the range.
 # Format: X, Y
 eye_gain: 1.0, 1.0
+
+# Asymmetric gain applied to the Y (up/down) axis *before* eye_gain's Y component.
+# Only the sign-matching side is multiplied:
+#   Gaze.y >= 0  ->  multiplied by eye_gain_y_up
+#   Gaze.y <  0  ->  multiplied by eye_gain_y_down
+# The final Gaze.y is clamped to [-1.0, +1.0].
+#
+# PICO Connect tends to under-report upward gaze (raw Up channel saturates ~0.25
+# while Down reaches ~0.65), so the upward eye motion feels weak on the avatar.
+# Recommended for PICO 4 Pro / Enterprise: eye_gain_y_up around 2.5 - 3.0,
+# eye_gain_y_down left at 1.0. Increase gradually; a value that makes forward
+# gaze look upward means the gain (or eye_gain Y) is too high.
+eye_gain_y_up: 1.0
+eye_gain_y_down: 1.0
 
 # Raw value CSV logger. When enabled, one row per received packet is written to
 # `log-file` (rate-limited by log-interval-ms). Useful for observing what PICO

--- a/VRCFTPicoModule/config.ini.example
+++ b/VRCFTPicoModule/config.ini.example
@@ -1,0 +1,34 @@
+# VRCFTPicoModule config.ini
+# Lines starting with '#' or ';' are comments. Each entry uses `key: value` format.
+#
+# On first run, this file is auto-created next to the module DLL
+# (%APPDATA%\VRCFaceTracking\CustomLibs\config.ini) with the same defaults.
+# Edit it in place and restart VRCFT to pick up changes.
+
+# Enable or disable tracking channels.
+# The legacy `.disable_eye` / `.disable_expression` flag files are still honored
+# for backwards compatibility.
+eye-tracking: enable
+expression-tracking: enable
+
+# Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown) diff.
+# 1.0 = pass-through (identical to upstream lonelyicer behavior).
+# Increase if your gaze feels too weak; decrease if it overshoots.
+# Format: X, Y
+eye_gain: 1.0, 1.0
+
+# Raw value CSV logger. When enabled, one row per received packet is written to
+# `log-file` (rate-limited by log-interval-ms). Useful for observing what PICO
+# Connect is actually sending, and for deciding what adjustments are needed.
+log-raw: disable
+
+# Path to the log CSV. Relative paths resolve next to the module DLL. Absolute
+# paths are honored as-is.
+log-file: PicoRawLog.csv
+
+# Minimum interval between logged rows in milliseconds. 0 = log every packet.
+log-interval-ms: 50
+
+# Include the 20 Pico visemes (index 52..71) in the CSV. These are not consumed
+# by the module today, but the values still arrive from PICO Connect.
+log-include-visemes: disable

--- a/VRCFTPicoModule/config.ini.example
+++ b/VRCFTPicoModule/config.ini.example
@@ -1,132 +1,180 @@
 # VRCFTPicoModule config.ini
 # Lines starting with '#' or ';' are comments. Each entry uses `key: value` format.
+# On first run this file is auto-created next to the module DLL
+# (%APPDATA%\VRCFaceTracking\CustomLibs\config.ini). Edit and restart VRCFT.
 #
-# On first run, this file is auto-created next to the module DLL
-# (%APPDATA%\VRCFaceTracking\CustomLibs\config.ini) with the same defaults.
-# Edit it in place and restart VRCFT to pick up changes.
+# VRCFTPicoModule config.ini
+# `#` または `;` で始まる行はコメント。各項目は `key: value` 形式。
+# 初回起動時にモジュールDLLの隣 (%APPDATA%\VRCFaceTracking\CustomLibs\config.ini)
+# に自動生成される。編集後は VRCFT を再起動して反映。
 
-# Enable or disable tracking channels.
-# The legacy `.disable_eye` / `.disable_expression` flag files are still honored
-# for backwards compatibility.
+# Enable or disable tracking channels. The legacy `.disable_eye` /
+# `.disable_expression` flag files are still honored for backwards compatibility.
+#
+# トラッキングチャネルの有効/無効。旧来の `.disable_eye` / `.disable_expression`
+# フラグファイルも後方互換のため引き続き有効。
 eye-tracking: enable
 expression-tracking: enable
 
-# Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown) diff.
-# 1.0 = pass-through (identical to upstream lonelyicer behavior).
-# Increase if your gaze feels too weak; decrease if it overshoots.
-# Final Gaze.x and Gaze.y are clamped to [-1.0, +1.0] regardless of this multiplier,
-# so values above 1.0 will saturate at the edges rather than extending the range.
-# Format: X, Y
+# Eye gaze multiplier applied after the (LookIn - LookOut) / (LookUp - LookDown)
+# diff. 1.0 = pass-through. Final Gaze.x/y are clamped to [-1.0, +1.0], so values
+# > 1.0 saturate at the edges rather than extending the range. Format: X, Y
+#
+# 視線倍率。(LookIn - LookOut) / (LookUp - LookDown) 差分の後に適用。
+# 1.0 でそのまま。最終値は [-1.0, +1.0] にクランプされるため、1.0超の値は
+# 範囲を広げるのではなく端で飽和する。フォーマット: X, Y
 eye_gain: 1.0, 1.0
 
-# Asymmetric gain applied to the Y (up/down) axis *before* eye_gain's Y component.
-# Only the sign-matching side is multiplied:
-#   Gaze.y >= 0  ->  multiplied by eye_gain_y_up
-#   Gaze.y <  0  ->  multiplied by eye_gain_y_down
-# The final Gaze.y is clamped to [-1.0, +1.0].
+# Asymmetric Y-axis gain applied *before* eye_gain's Y component. Only the
+# sign-matching side is multiplied (Gaze.y >= 0 uses _up, < 0 uses _down); the
+# final Gaze.y is still clamped to [-1.0, +1.0]. PICO Connect under-reports
+# upward gaze (raw Up saturates ~0.25 vs Down ~0.65), so recommended for
+# PICO 4 Pro / Enterprise: eye_gain_y_up = 2.5-3.0, eye_gain_y_down = 1.0.
 #
-# PICO Connect tends to under-report upward gaze (raw Up channel saturates ~0.25
-# while Down reaches ~0.65), so the upward eye motion feels weak on the avatar.
-# Recommended for PICO 4 Pro / Enterprise: eye_gain_y_up around 2.5 - 3.0,
-# eye_gain_y_down left at 1.0. Increase gradually; a value that makes forward
-# gaze look upward means the gain (or eye_gain Y) is too high.
+# Y軸(上下)の非対称ゲイン。eye_gain の Y 成分より *前* に適用され、符号が一致
+# する側のみ倍される (Gaze.y >= 0 は _up、< 0 は _down)。最終 Gaze.y は
+# [-1.0, +1.0] にクランプされる。PICO Connect は上方向視線を過小報告する
+# (raw Up は ~0.25 で飽和、Down は ~0.65)ため、PICO 4 Pro / Enterprise 推奨値:
+# eye_gain_y_up = 2.5〜3.0、eye_gain_y_down = 1.0。
 eye_gain_y_up: 1.0
 eye_gain_y_down: 1.0
 
 # ---- Mouth calibration ----------------------------------------------------
-# PICO Connect emits several mouth blendshapes with a persistent non-zero
-# baseline at rest (e.g. MouthFrown ~ 0.14 in a neutral face on PICO 4 Pro),
-# which shows up on the avatar as a permanent frown / puff / lip-roll. Each
-# calibrated shape below is transformed as:
+# PICO Connect emits several mouth blendshapes with a non-zero baseline at rest
+# (e.g. MouthFrown ~ 0.14 on PICO 4 Pro), producing a permanent frown/puff on
+# the avatar. Each calibrated shape is transformed as:
 #   output = clamp01((raw - floor) * gain)
-# so the floor cancels the resting bias and the gain restores expressive range.
-# Defaults are derived from observed PICO 4 Pro logs; adjust per user/hardware
-# by watching the raw CSV (see log-raw below).
+# Defaults come from PICO 4 Pro logs; tune per user by watching the raw CSV
+# (see log-raw below).
+#
+# ---- 口周りキャリブレーション ---------------------------------------------
+# PICO Connect の一部の口 blendshape は無表情時にも非ゼロ値を出力し
+# (例: PICO 4 Pro の MouthFrown ~ 0.14)、アバターが常に不機嫌な顔になる。
+# 各シェイプは以下の式で補正:
+#   output = clamp01((raw - floor) * gain)
+# デフォルトは PICO 4 Pro のログ由来。個別調整は log-raw の生値CSVを参照。
 
-# JawOpen ticks at ~0.05-0.08 at rest. Floor kills the idle wobble; gain stays
-# at 1.0 because JawOpen already covers a healthy dynamic range.
+# JawOpen ticks at ~0.05-0.08 at rest; floor kills idle wobble.
+# JawOpen は無表情時に ~0.05-0.08 で揺れる。floor でアイドル揺らぎを除去。
 jaw_open_floor: 0.05
 jaw_open_gain: 1.0
 
-# MouthFrown is the main "why does my avatar look sad" offender. Raw peaks for
-# an intentional frown are only ~0.23, so gain 2.0 recovers a visible range
-# after subtracting the ~0.14 rest floor.
+# MouthFrown raw peaks ~0.23 for an intentional frown, so gain 2.0 restores
+# a visible range after subtracting the ~0.14 rest floor.
+#
+# MouthFrown は意図的にしかめても raw のピークが ~0.23 しかないため、
+# ~0.14 の静止バイアスを引いた上で gain 2.0 により表現範囲を回復する。
 mouth_frown_floor: 0.14
 mouth_frown_gain: 2.0
 
 # MouthSmile has no meaningful rest floor. Bump the gain if smiles feel weak.
+# MouthSmile は静止バイアスなし。笑顔が弱いと感じたら gain を上げる。
 mouth_smile_gain: 1.0
 
 # MouthPucker sits around 0.10-0.12 at rest.
+# MouthPucker は無表情時 ~0.10-0.12。
 mouth_pucker_floor: 0.10
 mouth_pucker_gain: 1.0
 
 # MouthFunnel and both MouthRoll channels have small but consistent floors.
+# MouthFunnel と MouthRoll (上下) は小さいが安定した底値をもつ。
 mouth_funnel_floor: 0.05
 mouth_roll_lower_floor: 0.16
 mouth_roll_upper_floor: 0.05
 
 # ---- Cheek channels -------------------------------------------------------
-# PICO Connect does not reliably drive CheekPuff or CheekSquint on tested
-# firmware (CheekPuff stays pinned near its noise floor even during a real
-# puff; CheekSquint is emitted as a constant). Disabled by default so the
-# avatar's cheeks stay still. Re-enable if your hardware/firmware differs.
+# PICO Connect doesn't reliably drive CheekPuff (pinned near noise floor even
+# during a real puff) or CheekSquint (emitted as a constant). Disabled by
+# default; re-enable if your hardware/firmware differs.
+#
+# ---- 頬チャネル -----------------------------------------------------------
+# PICO Connect は CheekPuff (実際に頬を膨らませてもノイズ底に張り付く) と
+# CheekSquint (定数出力) を正しく駆動しない。既定で無効。動作するハードや
+# ファームでは有効化して構わない。
 cheek_puff: disable
 cheek_puff_floor: 0.14
 cheek_puff_gain: 1.0
 
 # When cheek_puff is enabled and calibrated CheekPuff exceeds this threshold,
 # a heuristic re-routes the puff to the OPPOSITE cheek from a clearly-shifted
-# mouth. Raise this if a plain mouth-shift accidentally triggers a puff.
+# mouth. Raise if a plain mouth-shift accidentally triggers a puff.
+#
+# cheek_puff 有効時、補正後の CheekPuff がこの閾値を超えると、口のシフト方向
+# と逆側の頬に puff を振り替えるヒューリスティックが働く。単なる口のシフトで
+# puff が誤発火する場合は値を上げる。
 cheek_puff_cross_threshold: 0.25
 
 cheek_squint: disable
 
-# PICO Connect fires MouthLeft and MouthRight together when the mouth shifts
-# to one side, causing bleed onto the opposite side of the avatar. Differential
-# mode passes only the dominant side: max(0, MouthLeft - MouthRight) etc.
-# Disable only if your avatar rig expects raw simultaneous values.
+# PICO Connect fires MouthLeft and MouthRight together when the mouth shifts,
+# causing bleed onto the opposite side. Differential mode passes only the
+# dominant side: max(0, MouthLeft - MouthRight). Disable only if your avatar
+# rig expects the raw simultaneous values.
+#
+# PICO Connect は口が片側にシフトすると MouthLeft と MouthRight を同時に
+# 出力し、反対側にブリードが出る。差分モードは優勢側のみ通す:
+# max(0, MouthLeft - MouthRight)。アバターリグが raw の同時値を期待する
+# 場合のみ無効化。
 mouth_lr_differential: enable
 
 # ---- Wink latch -----------------------------------------------------------
 # When one eye is winked while the other looks toward the FOV edge, PICO's
-# blink estimator falls back to a symmetric value (both eyes ~0.4-0.6), so
-# the avatar half-lids on both sides. The latch arms on a clean wink and
-# re-emits the last non-collapsed EyeBlink_L / EyeBlink_R pair while the raw values
-# sit in the symmetric-collapse zone. It releases as soon as both eyes clearly
-# open or a real double blink is detected, so ordinary blinking is untouched.
-# Disable if your firmware doesn't exhibit the fallback or you prefer the
-# raw PICO output.
+# blink estimator collapses to a symmetric fallback (~0.4-0.6 on both eyes),
+# half-lidding the avatar. The latch arms on a clean wink and re-emits the
+# last non-collapsed EyeBlink_L / EyeBlink_R while raw values sit in the
+# symmetric-collapse zone. It releases on eyes-open or a real double blink,
+# so ordinary blinking is untouched. Disable if your firmware doesn't exhibit
+# the fallback or you prefer raw PICO output.
+#
+# ---- Wink ラッチ ----------------------------------------------------------
+# 片眼をウィンクしつつもう片方が FOV 端を見ると、PICO のまばたき推定が対称
+# フォールバック (両眼 ~0.4-0.6) に落ちてアバターが両目とも半目になる。
+# ラッチはクリーンなウィンクで動作し、raw が対称崩壊域にある間は直前の
+# 非崩壊な EyeBlink_L / EyeBlink_R を再送出。両眼開きまたは通常の両眼
+# まばたきで解除されるため、普段のまばたきは影響を受けない。この症状が
+# 出ないファーム、または PICO の raw 出力を優先したい場合は無効化。
 wink_latch: enable
 
-# Blink >= trigger_high means the eye is considered closed enough to arm as
-# the "winking side"; the opposite eye must be <= trigger_low to count as
-# open. trigger_high is also the ceiling of the symmetric-collapse override
-# zone (see collapse_low below).
+# trigger_high = closed enough to arm as the winking side (also the ceiling
+#                of the symmetric-collapse override zone).
+# trigger_low  = opposite eye must be at or below this to count as open.
+# collapse_low = lower bound of the symmetric-collapse zone; keep it slightly
+#                above trigger_low so genuinely opening eyes pass through.
+# symmetry_band = |EyeBlink_L - EyeBlink_R| tolerance inside the collapse zone.
+#
+# trigger_high = ウィンク側として認定するための閉眼の下限 (対称崩壊上書き域の
+#                上限も兼ねる)。
+# trigger_low  = 反対側の眼が開いていると認定するための上限。
+# collapse_low = 対称崩壊域の下限。trigger_low よりわずかに上に置いて、
+#                本当に開こうとしている眼はそのまま通す。
+# symmetry_band = 崩壊域内で許容する |EyeBlink_L - EyeBlink_R| の幅。
 wink_latch_trigger_high: 0.65
 wink_latch_trigger_low: 0.30
-
-# Symmetric-collapse detection: while latched, if both eyes sit in
-# [collapse_low, trigger_high) with |EyeBlink_L - EyeBlink_R| < symmetry_band,
-# the last non-collapsed pair is re-emitted instead of the collapsed values.
-# Keep collapse_low slightly above trigger_low: values falling through the
-# (trigger_low, collapse_low) gap are treated as genuinely opening eyes and
-# pass through immediately instead of being held.
 wink_latch_collapse_low: 0.35
 wink_latch_symmetry_band: 0.10
 
-# Raw value CSV logger. When enabled, one row per received packet is written to
-# `log-file` (rate-limited by log-interval-ms). Useful for observing what PICO
-# Connect is actually sending, and for deciding what adjustments are needed.
+# Raw value CSV logger. Writes one row per received packet to `log-file`
+# (rate-limited by log-interval-ms). Useful for observing what PICO Connect
+# actually sends and deciding what adjustments are needed.
+#
+# 生値CSVロガー。受信パケット1件につき1行を `log-file` に書き込む
+# (log-interval-ms でレート制限)。PICO Connect が実際に送っている値の確認と
+# 調整方針の判断に有用。
 log-raw: disable
 
-# Path to the log CSV. Relative paths resolve next to the module DLL. Absolute
-# paths are honored as-is.
+# Path to the log CSV. Relative paths resolve next to the module DLL.
+# Absolute paths are honored as-is.
+#
+# ログCSVのパス。相対パスはモジュールDLL隣で解決。絶対パスはそのまま使用。
 log-file: PicoRawLog.csv
 
 # Minimum interval between logged rows in milliseconds. 0 = log every packet.
+# ログ行の最小間隔(ミリ秒)。0 で全パケット記録。
 log-interval-ms: 50
 
-# Include the 20 Pico visemes (index 52..71) in the CSV. These are not consumed
-# by the module today, but the values still arrive from PICO Connect.
+# Include the 20 Pico visemes (index 52..71) in the CSV. Not consumed by the
+# module today, but the values still arrive from PICO Connect.
+#
+# CSV に PICO の20個の viseme (index 52..71) を含める。現状モジュールは未使用
+# だが、PICO Connect からは値が到達している。
 log-include-visemes: disable

--- a/VRCFTPicoModule/config.ini.example
+++ b/VRCFTPicoModule/config.ini.example
@@ -92,7 +92,7 @@ mouth_lr_differential: enable
 # When one eye is winked while the other looks toward the FOV edge, PICO's
 # blink estimator falls back to a symmetric value (both eyes ~0.4-0.6), so
 # the avatar half-lids on both sides. The latch arms on a clean wink and
-# re-emits the last clean EyeBlink_L / EyeBlink_R pair while the raw values
+# re-emits the last non-collapsed EyeBlink_L / EyeBlink_R pair while the raw values
 # sit in the symmetric-collapse zone. It releases as soon as both eyes clearly
 # open or a real double blink is detected, so ordinary blinking is untouched.
 # Disable if your firmware doesn't exhibit the fallback or you prefer the
@@ -108,7 +108,7 @@ wink_latch_trigger_low: 0.30
 
 # Symmetric-collapse detection: while latched, if both eyes sit in
 # [collapse_low, trigger_high) with |EyeBlink_L - EyeBlink_R| < symmetry_band,
-# the last clean pair is re-emitted instead of the collapsed values.
+# the last non-collapsed pair is re-emitted instead of the collapsed values.
 # Keep collapse_low slightly above trigger_low: values falling through the
 # (trigger_low, collapse_low) gap are treated as genuinely opening eyes and
 # pass through immediately instead of being held.

--- a/VRCFTPicoModule/config.ini.example
+++ b/VRCFTPicoModule/config.ini.example
@@ -33,6 +33,61 @@ eye_gain: 1.0, 1.0
 eye_gain_y_up: 1.0
 eye_gain_y_down: 1.0
 
+# ---- Mouth calibration ----------------------------------------------------
+# PICO Connect emits several mouth blendshapes with a persistent non-zero
+# baseline at rest (e.g. MouthFrown ~ 0.14 in a neutral face on PICO 4 Pro),
+# which shows up on the avatar as a permanent frown / puff / lip-roll. Each
+# calibrated shape below is transformed as:
+#   output = clamp01((raw - floor) * gain)
+# so the floor cancels the resting bias and the gain restores expressive range.
+# Defaults are derived from observed PICO 4 Pro logs; adjust per user/hardware
+# by watching the raw CSV (see log-raw below).
+
+# JawOpen ticks at ~0.05-0.08 at rest. Floor kills the idle wobble; gain stays
+# at 1.0 because JawOpen already covers a healthy dynamic range.
+jaw_open_floor: 0.05
+jaw_open_gain: 1.0
+
+# MouthFrown is the main "why does my avatar look sad" offender. Raw peaks for
+# an intentional frown are only ~0.23, so gain 2.0 recovers a visible range
+# after subtracting the ~0.14 rest floor.
+mouth_frown_floor: 0.14
+mouth_frown_gain: 2.0
+
+# MouthSmile has no meaningful rest floor. Bump the gain if smiles feel weak.
+mouth_smile_gain: 1.0
+
+# MouthPucker sits around 0.10-0.12 at rest.
+mouth_pucker_floor: 0.10
+mouth_pucker_gain: 1.0
+
+# MouthFunnel and both MouthRoll channels have small but consistent floors.
+mouth_funnel_floor: 0.05
+mouth_roll_lower_floor: 0.16
+mouth_roll_upper_floor: 0.05
+
+# ---- Cheek channels -------------------------------------------------------
+# PICO Connect does not reliably drive CheekPuff or CheekSquint on tested
+# firmware (CheekPuff stays pinned near its noise floor even during a real
+# puff; CheekSquint is emitted as a constant). Disabled by default so the
+# avatar's cheeks stay still. Re-enable if your hardware/firmware differs.
+cheek_puff: disable
+cheek_puff_floor: 0.14
+cheek_puff_gain: 1.0
+
+# When cheek_puff is enabled and calibrated CheekPuff exceeds this threshold,
+# a heuristic re-routes the puff to the OPPOSITE cheek from a clearly-shifted
+# mouth. Raise this if a plain mouth-shift accidentally triggers a puff.
+cheek_puff_cross_threshold: 0.25
+
+cheek_squint: disable
+
+# PICO Connect fires MouthLeft and MouthRight together when the mouth shifts
+# to one side, causing bleed onto the opposite side of the avatar. Differential
+# mode passes only the dominant side: max(0, MouthLeft - MouthRight) etc.
+# Disable only if your avatar rig expects raw simultaneous values.
+mouth_lr_differential: enable
+
 # Raw value CSV logger. When enabled, one row per received packet is written to
 # `log-file` (rate-limited by log-interval-ms). Useful for observing what PICO
 # Connect is actually sending, and for deciding what adjustments are needed.


### PR DESCRIPTION
## Summary
- `config.ini.example` と `Config.cs` の `DefaultIniTemplate()` の全コメントを **英語 → 日本語の順で併記** した。
- 併記で長くなりすぎないよう、既に冗長だった英文 (eye_gain / eye_gain_y_up・down / mouth calibration イントロ / cheek channels / wink latch) を圧縮。結果、132 → 180 行 (+36%) に収めた (両言語混載を考えると軽微)。
- すべての `key: value` 行と数値デフォルトは無変更。`config.ini.example` と `DefaultIniTemplate()` の生成テンプレートが完全一致することを diff で検証済み。

## 変更したもの
| ファイル | 内容 |
|---|---|
| `VRCFTPicoModule/config.ini.example` | 132 → 180 行、EN+JA 併記 |
| `VRCFTPicoModule/Utils/Config.cs` | `DefaultIniTemplate()` を上記と完全一致に |

## 変更していないもの
- 設定キー名 / 値 / デフォルト
- パーサ (`ApplyKey`)、コメント判定 (`#` / `;` 始まりをスキップ) は既存のままなので日本語コメントも安全に無視される
- 旧来の `.disable_eye` / `.disable_expression` フラグへの言及も維持

## Test plan
- [ ] Windows 上で `dotnet build` が通ることを確認 (Mac ローカルに .NET がなく未検証)
- [ ] VRCFT 起動 → 既存 `config.ini` が読み込まれ、warning が出ないこと
- [ ] `config.ini` を削除して VRCFT を起動 → 自動生成されるテンプレートが本 PR の `config.ini.example` と一致すること
- [ ] 生成されたテンプレートに含まれる日本語コメントが化けないこと (書き出しは UTF-8 前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)